### PR TITLE
chore(npm): ignore workspaces by npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+workspaces-update=false


### PR DESCRIPTION
Исправляет ошибку при попытке сделать npm release (используется внутри semantic-release)