### PR TITLE
fix(webpack-client): add NODE_ENV variable in dev mode

### DIFF
--- a/packages/arui-scripts/src/configs/webpack.client.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.ts
@@ -323,7 +323,13 @@ export const createClientWebpackConfig = (mode: 'dev' | 'prod'): Configuration =
         new AssetsPlugin({ path: configs.serverOutputPath }),
         new webpack.DefinePlugin({
             // Tell Webpack to provide empty mocks for process.env.
-            'process.env': '{}'
+            'process.env': '{}',
+            // В прод режиме webpack автоматически подставляет NODE_ENV=production, но нам нужно чтобы эта переменная
+            // была доступна всегда. При этом мы не хотим давать возможность переопределять ее в production режиме.
+            ...(mode === 'dev'
+                ? { 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV) }
+                : {}
+            ),
         }),
         new MiniCssExtractPlugin({
             filename: '[name].[contenthash:8].css',


### PR DESCRIPTION
Исправление небольшой ошибки в том, как определяется NODE_ENV переменная. В прод режиме ее всегда сам определяет вебпак, для дев режима ранее был вот такой https://github.com/core-ds/arui-scripts/blob/v14.0.0/packages/arui-scripts/src/configs/webpack.client.prod.ts#L310 костыль.

Не хочется давать возможность определять кастомный NODE_ENV для продакшен сборок, но для дев режима, чтобы не ломать совместимость, эту возможность лучше оставить.