### PR TITLE
fix(webpack.client.ts): fix #13

### DIFF
--- a/packages/arui-scripts-test/package.json
+++ b/packages/arui-scripts-test/package.json
@@ -12,7 +12,7 @@
     },
     "scripts": {
         "build": "arui-scripts build",
-        "start": "arui-scripts start",
+        "start": "NODE_ENV=localhost arui-scripts start",
         "test": "arui-scripts test",
         "bundle-analyze": "arui-scripts bundle-analyze",
         "ci": "yarn run test && yarn run build"

--- a/packages/arui-scripts/src/configs/webpack.client.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.ts
@@ -200,7 +200,7 @@ export const createClientWebpackConfig = (mode: 'dev' | 'prod'): Configuration =
                             cacheCompression: false,
                             plugins: [
                                 ...babelConf.plugins,
-                                mode === 'dev' ? require.resolve('react-refresh/babel') : undefined
+                                mode === 'dev' ? [require.resolve('react-refresh/babel'), {skipEnvCheck: true}] : undefined
                             ].filter(Boolean),
                         },
                     },
@@ -212,7 +212,7 @@ export const createClientWebpackConfig = (mode: 'dev' | 'prod'): Configuration =
                                 options: Object.assign({
                                     cacheDirectory: mode === 'dev',
                                     cacheCompression: false,
-                                    plugins: mode === 'dev' ? require.resolve('react-refresh/babel') : undefined,
+                                    plugins: mode === 'dev' ? [require.resolve('react-refresh/babel'), {skipEnvCheck: true}] : undefined,
                                 }, babelConf)
                             },
                             {


### PR DESCRIPTION
Если в arui-scripts start всегда используется dev-конфиг, то имеет смысл сделать скип проверки NODE_ENV для react-refresh-/babel