### PR TITLE
fix(docker): chagne output format for docker build to support older client

### DIFF
--- a/.github/workflows/alpine-node.yml
+++ b/.github/workflows/alpine-node.yml
@@ -17,22 +17,15 @@ jobs:
         version: [14.21.3, 16.20.0, 18.16.0]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v1
         with:
+          path: packages/alpine-node-nginx/
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          outputs: type=docker
-          tags: ${{ matrix.version == env.LATEST_VERSION && format('alfabankui/arui-scripts:{0},alfabankui/arui-scripts:latest', matrix.version) || format('alfabankui/arui-scripts:{0}', matrix.version) }}
-          build-args: |
-            NODE_VERSION=${{ matrix.version }}
-            ALPINE_VERSION=3.16
-          context: ./packages/alpine-node-nginx
+          repository: alfabankui/arui-scripts
+          build_args: NODE_VERSION=${{ matrix.version }},ALPINE_VERSION=3.16
+          tags: ${{ matrix.version == env.LATEST_VERSION && format('{0},latest', matrix.version) || matrix.version }}

--- a/.github/workflows/alpine-node.yml
+++ b/.github/workflows/alpine-node.yml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          outputs: type=docker
           tags: ${{ matrix.version == env.LATEST_VERSION && format('alfabankui/arui-scripts:{0},alfabankui/arui-scripts:latest', matrix.version) || format('alfabankui/arui-scripts:{0}', matrix.version) }}
           build-args: |
             NODE_VERSION=${{ matrix.version }}


### PR DESCRIPTION
Новый buildx выдает образы в формате, не совместимом с docker 1.13.0, который, к сожалению, используется на части наших серверов