### PR TITLE
chore(*): fix #23

### DIFF
--- a/packages/arui-scripts/package.json
+++ b/packages/arui-scripts/package.json
@@ -55,7 +55,7 @@
         "expose-loader": "3.0.0",
         "file-loader": "6.2.0",
         "filesize": "^6.1.0",
-        "fork-ts-checker-webpack-plugin": "6.3.5",
+        "fork-ts-checker-webpack-plugin": "6.5.3",
         "fs-extra": "6.0.1",
         "gzip-size": "5.1.1",
         "jest": "28.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5269,7 +5269,7 @@ __metadata:
     expose-loader: 3.0.0
     file-loader: 6.2.0
     filesize: ^6.1.0
-    fork-ts-checker-webpack-plugin: 6.3.5
+    fork-ts-checker-webpack-plugin: 6.5.3
     fs-extra: 6.0.1
     gzip-size: 5.1.1
     jest: 28.1.3
@@ -9400,9 +9400,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fork-ts-checker-webpack-plugin@npm:6.3.5":
-  version: 6.3.5
-  resolution: "fork-ts-checker-webpack-plugin@npm:6.3.5"
+"fork-ts-checker-webpack-plugin@npm:6.5.3":
+  version: 6.5.3
+  resolution: "fork-ts-checker-webpack-plugin@npm:6.5.3"
   dependencies:
     "@babel/code-frame": ^7.8.3
     "@types/json-schema": ^7.0.5
@@ -9427,7 +9427,7 @@ __metadata:
       optional: true
     vue-template-compiler:
       optional: true
-  checksum: 3cb33007a5452c4a0dd3c9510d9f5cedf146770a706a1503afcb8b02b140aaf980e84fec6cf1300b77625e0d385df8faf7410e1f4a6497c616bda2d66929248b
+  checksum: 9732a49bfeed8fc23e6e8a59795fa7c238edeba91040a9b520db54b4d316dda27f9f1893d360e296fd0ad8930627d364417d28a8c7007fba60cc730ebfce4956
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Апдейт fork-ts-checker до версии 6.5.3, чтобы не было варнингов при typescript@5