### PR TITLE
feat(webpack): ignore momentjs locales

### DIFF
--- a/packages/arui-scripts/src/configs/webpack.client.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.ts
@@ -339,7 +339,13 @@ export const createClientWebpackConfig = (mode: 'dev' | 'prod'): Configuration =
             chunkFilename: mode === 'dev' ? '[id].css' : '[name].[contenthash:8].chunk.css',
         }),
         configs.tsconfig !== null && new ForkTsCheckerWebpackPlugin(),
-
+        // moment.js очень большая библиотека, которая включает в себя массу локализаций, которые мы не используем.
+        // Поэтому мы их просто игнорируем, чтобы не включать в сборку.
+        // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
+        new webpack.IgnorePlugin({
+            resourceRegExp: /^\.\/locale$/,
+            contextRegExp: /moment$/,
+        }),
         // dev plugins:
         mode === 'dev' && new ReactRefreshWebpackPlugin({
             overlay: false,


### PR DESCRIPTION
В какой то момент времени мы потеряли эту оптимизацию сборки. moment.js все еще используется на ряде проектов, при этом он несет с собой огромное кол-во кода локализаций. 
Фиксим это, выкидывая их из сборки вебпака.