### PR TITLE
feat(*): compress wasm with gzip

### DIFF
--- a/packages/alpine-node-nginx/nginx.conf
+++ b/packages/alpine-node-nginx/nginx.conf
@@ -23,6 +23,8 @@ http {
     tcp_nodelay             on;
 
     gzip_static             on;
+    gzip                    on;
+    gzip_types              application/wasm;
     brotli                  on;
     brotli_static           on;
     brotli_types            application/atom+xml application/javascript application/json application/rss+xml


### PR DESCRIPTION
Возникла необходимость сжимать gzip'ом wasm файлы предоставляемые библиотекой Smart Engines, которую мы используем для распознавания изображений