### PR TITLE
feat(*): compress wasm with brotli

### DIFF
--- a/packages/alpine-node-nginx/nginx.conf
+++ b/packages/alpine-node-nginx/nginx.conf
@@ -23,15 +23,13 @@ http {
     tcp_nodelay             on;
 
     gzip_static             on;
-    gzip                    on;
-    gzip_types              application/wasm;
     brotli                  on;
     brotli_static           on;
     brotli_types            application/atom+xml application/javascript application/json application/rss+xml
                             application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype
                             application/x-font-ttf application/x-javascript application/xhtml+xml application/xml
                             font/eot font/opentype font/otf font/truetype image/svg+xml image/vnd.microsoft.icon
-                            image/x-icon image/x-win-bitmap text/css text/javascript text/plain text/xml;
+                            image/x-icon image/x-win-bitmap text/css text/javascript text/plain text/xml application/wasm;
 
 
     # Only retry if there was a communication error, not a timeout


### PR DESCRIPTION
После обсуждения решили сжимать при помощи brotli вместо gzip т.к. сжимает эффективнее + возможно, настройка `gzip_types  application/wasm;` могла переопределять какие-то дефолтные типы для gzip сжатия.

Ревертнул настройку для gzip, добавил соответствующий тип файла для brotli