### PR TITLE
fix(bundle-analyze): allow bundle analyzer to work with multiple configs

### DIFF
--- a/.changeset/four-eels-own.md
+++ b/.changeset/four-eels-own.md
@@ -1,0 +1,5 @@
+---
+"arui-scripts": patch
+---
+
+Work correctly with multiple webpack configuration for client bundles

--- a/packages/arui-scripts/src/commands/build/build-wrapper.ts
+++ b/packages/arui-scripts/src/commands/build/build-wrapper.ts
@@ -6,13 +6,13 @@ import webpack from 'webpack';
 import formatWebpackMessages from '../util/format-webpack-messages';
 
 type BuildResult = {
-    stats: webpack.Stats;
+    stats: webpack.Stats | webpack.MultiStats;
     warnings: string[];
     previousFileSizes: unknown;
 }
 
-function build(config: webpack.Configuration, previousFileSizes?: unknown) {
-    let compiler = webpack(config);
+function build(config: webpack.Configuration | webpack.Configuration[], previousFileSizes?: unknown) {
+    let compiler = webpack(config as webpack.Configuration);
     return new Promise<BuildResult>((resolve, reject) => {
         compiler.run((err: any, stats: any) => {
             if (err) {

--- a/packages/arui-scripts/src/commands/build/client.ts
+++ b/packages/arui-scripts/src/commands/build/client.ts
@@ -2,10 +2,11 @@
 /* eslint no-console: 0 */
 import chalk from 'chalk';
 import printBuildError from 'react-dev-utils/printBuildError';
-import { Configuration } from 'webpack';
+import { Configuration, Stats } from 'webpack';
 import build from './build-wrapper';
 import { calculateAssetsSizes, printAssetsSizes } from '../util/client-assets-sizes';
 import config from '../../configs/webpack.client.prod';
+import { MultiStats } from 'webpack';
 
 console.log(chalk.magenta('Building client...'));
 
@@ -24,15 +25,16 @@ build(config)
             console.log(chalk.green('Client compiled successfully.\n'));
         }
 
-        function printOutputSizes(webpackConfig: Configuration) {
+        function printOutputSizes(webpackConfig: Configuration, stats: Stats) {
             const sizes = calculateAssetsSizes(stats, webpackConfig?.output?.path);
             printAssetsSizes(sizes);
         }
 
+
         if (Array.isArray(config)) {
-            config.forEach(printOutputSizes)
+            config.forEach((conf, index) => printOutputSizes(conf, (stats as MultiStats).stats[index]));
         } else {
-            printOutputSizes(config);
+            printOutputSizes(config, stats as Stats);
         }
     })
     .catch((err) => {

--- a/packages/arui-scripts/src/commands/util/make-tmp-dir.ts
+++ b/packages/arui-scripts/src/commands/util/make-tmp-dir.ts
@@ -9,8 +9,8 @@ const nodeMakeTmpDir = util.promisify(fs.mkdtemp);
  * Создает и возвращает временную папку
  * @returns {Promise<string>}
  */
-async function makeTmpDir() {
-    return await nodeMakeTmpDir(`${os.tmpdir()}${path.sep}`);
+async function makeTmpDir(prefix?: string) {
+    return await nodeMakeTmpDir(path.join(os.tmpdir(), prefix || ''));
 }
 
 export default makeTmpDir;

--- a/packages/arui-scripts/src/commands/util/run-client-dev-server.ts
+++ b/packages/arui-scripts/src/commands/util/run-client-dev-server.ts
@@ -4,12 +4,9 @@ import devServerConfig from '../../configs/dev-server';
 import printCompilerOutput from '../start/print-compiler-output';
 import { choosePort } from 'react-dev-utils/WebpackDevServerUtils';
 
-export async function runClientDevServer(configuration: Configuration) {
-    const clientCompiler = webpack(configuration);
-    // не резолвиться constructor(config: WebpackDevServer.Configuration, webpack?: webpack.Compiler | webpack.MultiCompiler);
-    // clientCompiler: webpack.Compiler
-    // @ts-ignore
-    const clientDevServer = new WebpackDevServer(devServerConfig, clientCompiler);
+export async function runClientDevServer(configuration: Configuration | Configuration[]) {
+    const clientCompiler = webpack(configuration as Configuration); // типы вебпака не умеют выбирать между конфигурациями и массивом конфигураций
+    const clientDevServer = new WebpackDevServer(devServerConfig, clientCompiler as any);
 
     clientCompiler.hooks.invalid.tap('client', () => console.log('Compiling client...'));
     clientCompiler.hooks.done.tap('client', (stats: any) => printCompilerOutput('Client', stats));


### PR DESCRIPTION
Попытка разбить пул-реквест с модулями на чуть более мелкие и понятные части. Этих пул-реквестов будет несколько последовательно.

Добавляем поддержку работы с множеством конфигов вебпака. Позволяет нормально выводить информацию о сборке в консоль и фиксит работу команды bundle-analyze.