### PR TITLE
feat(webpack): add createSingleWebpackConfig method

### DIFF
--- a/.changeset/fuzzy-boxes-juggle.md
+++ b/.changeset/fuzzy-boxes-juggle.md
@@ -1,0 +1,5 @@
+---
+"arui-scripts": minor
+---
+
+Add helper to build a separate webpack configuration

--- a/packages/arui-scripts-test/arui-scripts.overrides.ts
+++ b/packages/arui-scripts-test/arui-scripts.overrides.ts
@@ -1,4 +1,4 @@
-import type { OverrideFile } from "arui-scripts";
+import { OverrideFile } from "arui-scripts";
 
 const overrides: OverrideFile = {
     webpackServer: (config) => ({
@@ -8,6 +8,18 @@ const overrides: OverrideFile = {
             { express: "commonjs express" },
         ],
     }),
+    webpackClient: (config, appConfig, { createSingleClientWebpackConfig }) => {
+        const workerConfig = createSingleClientWebpackConfig(
+            { worker: './src/worker.ts' },
+            'worker',
+        );
+        workerConfig.output.filename = 'worker.js';
+
+        return [
+            config,
+            workerConfig,
+        ];
+    },
     postcss(config) {
         return [
             ...config,

--- a/packages/arui-scripts-test/src/client.tsx
+++ b/packages/arui-scripts-test/src/client.tsx
@@ -24,3 +24,7 @@ if (process.env.NODE_ENV !== 'production' && module.hot) {
         targetElement
     );
 }
+
+if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register("/assets/worker.js");
+}

--- a/packages/arui-scripts-test/src/worker.ts
+++ b/packages/arui-scripts-test/src/worker.ts
@@ -1,0 +1,7 @@
+// This code executes in its own worker or thread
+self.addEventListener("install", event => {
+    console.log("Service worker installed");
+});
+self.addEventListener("activate", event => {
+    console.log("Service worker activated");
+});

--- a/packages/arui-scripts/README.md
+++ b/packages/arui-scripts/README.md
@@ -626,16 +626,13 @@ export default overrides;
 service worker'а (или любых других кейсов). Для этого можно использовать функцию-хелпер `createSingleWebpackConfig`:
 
 ```ts
-import {
-    OverrideFile,
-    createSingleWebpackConfig,
-} from 'arui-scripts';
+import type { OverrideFile } from 'arui-scripts';
 
 const overrides: OverrideFile = {
-    webpack: (config) => {
+    webpackClient: (config, appConfig, { createSingleClientWebpackConfig }) => {
         return [
             config,
-            createSingleWebpackConfig(
+            createSingleClientWebpackConfig(
                 './src/sw.js', // entrypoint, может быть массивом/объектом
                 'sw', // наименование сборки, влияет на имена чанков
             ),

--- a/packages/arui-scripts/README.md
+++ b/packages/arui-scripts/README.md
@@ -590,7 +590,7 @@ export default overrides;
             const { files } = postcssPluginsOptions['@csstools/postcss-global-data'];
             const newOption = {
                 ...postcssPluginsOptions,
-                '@csstools/postcss-global-data': { 
+                '@csstools/postcss-global-data': {
                     files:files.concat(['./vars.css'])
                 }
             };
@@ -620,6 +620,35 @@ export default overrides;
 - `serverExternalsExemptions` - список модулей, которые не будут добавлены в список внешних зависимостей сервера. [Подробнее](#node-externals).
 
 Для некоторых конфигураций определены несколько ключей, они будут применяться в том порядке, в котором они приведены в этом файле.
+
+### Создание дополнительных конфигураций для webpack
+На некоторых проектах может потребоваться создать дополнительные конфигурации для webpack. Например, для создания
+service worker'а (или любых других кейсов). Для этого можно использовать функцию-хелпер `createSingleWebpackConfig`:
+
+```ts
+import {
+    OverrideFile,
+    createSingleWebpackConfig,
+} from 'arui-scripts';
+
+const overrides: OverrideFile = {
+    webpack: (config) => {
+        return [
+            config,
+            createSingleWebpackConfig(
+                './src/sw.js', // entrypoint, может быть массивом/объектом
+                'sw', // наименование сборки, влияет на имена чанков
+            ),
+        ];
+    }
+};
+
+export default overrides;
+```
+Эта функция вернет независимую конфигурацию для webpack, которую можно использовать в качестве оверрайда. Вы так же можете ее модифицировать,
+не боясь что это повлияет на другие конфигурации.
+
+Созданная таким образом конфигурация будет шарить с оригинальной конфигурацией только плагин для формирования assets-manifest'а.
 
 Пресеты
 ===

--- a/packages/arui-scripts/src/configs/postcss.config.ts
+++ b/packages/arui-scripts/src/configs/postcss.config.ts
@@ -6,7 +6,7 @@ import path from 'path';
  * @param {Object} options коллекция конфигураций плагинов, где ключ - название плагина, а значение - аргумент для инициализации
  * @returns {*}
  */
-export function createPostcssConfig(plugins: string[], options: Record<string, unknown>) {
+export function createPostcssConfig(plugins: string[], options: Record<string, unknown>): string[] | unknown[] {
     return plugins.map(pluginName => {
         if (pluginName in options) {
             return [pluginName, options[pluginName]];

--- a/packages/arui-scripts/src/configs/process-assets-plugin-output.ts
+++ b/packages/arui-scripts/src/configs/process-assets-plugin-output.ts
@@ -1,0 +1,34 @@
+import { Assets } from 'assets-webpack-plugin';
+import configs from './app-configs';
+
+export function processAssetsPluginOutput(assets: Assets) {
+    let adjustedAssets = assets;
+
+    Object.keys(adjustedAssets).forEach((key) => {
+        // заменяем путь к файлам на корректный в случае если в нем есть 'auto/'
+        adjustedAssets[key] = {
+            css: replaceAutoPath(adjustedAssets[key].css) as any,
+            js: replaceAutoPath(adjustedAssets[key].js) as any,
+        };
+    });
+
+    const result = {
+        ...adjustedAssets,
+        __metadata__: {
+            version: configs.version,
+            name: configs.normalizedName,
+        },
+    };
+
+    return JSON.stringify(result);
+}
+
+function replaceAutoPath(assets: string | string[] | undefined) {
+    if (!assets) {
+        return assets;
+    }
+    if (Array.isArray(assets)) {
+        return assets.map((asset) => asset.replace(/^auto\//, configs.publicPath));
+    }
+    return assets.replace(/^auto\//, configs.publicPath);
+}

--- a/packages/arui-scripts/src/configs/util/__tests__/apply-overrides.tests.ts
+++ b/packages/arui-scripts/src/configs/util/__tests__/apply-overrides.tests.ts
@@ -45,7 +45,7 @@ it('should call override function and update config', () => {
     const applyOverrides = require('../apply-overrides').default;
 
     expect(applyOverrides('foo', {})).toBe('new value');
-    expect(override).toHaveBeenCalledWith({}, { overridesPath: ['overrides'] });
+    expect(override).toHaveBeenCalledWith({}, { overridesPath: ['overrides'] }, undefined);
 });
 
 it('should call multiple override functions and update config with latest value', () => {
@@ -61,6 +61,6 @@ it('should call multiple override functions and update config with latest value'
     const applyOverrides = require('../apply-overrides').default;
 
     expect(applyOverrides(['foo', 'bar'], {})).toBe('new value2');
-    expect(override1).toHaveBeenCalledWith({}, { overridesPath: ['overrides'] });
-    expect(override2).toHaveBeenCalledWith('new value', { overridesPath: ['overrides'] });
+    expect(override1).toHaveBeenCalledWith({}, { overridesPath: ['overrides'] }, undefined);
+    expect(override2).toHaveBeenCalledWith('new value', { overridesPath: ['overrides'] }, undefined);
 });

--- a/packages/arui-scripts/src/configs/util/apply-overrides.ts
+++ b/packages/arui-scripts/src/configs/util/apply-overrides.ts
@@ -2,6 +2,7 @@ import type { Configuration as WebpackConfiguration, WebpackOptionsNormalized } 
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import appConfigs from '../app-configs';
 import { AppConfigs } from '../app-configs/types';
+import { createSingleClientWebpackConfig } from "../webpack.client";
 
 type Overrides = {
     webpack: WebpackConfiguration | WebpackConfiguration[];
@@ -32,7 +33,28 @@ type Overrides = {
     serverExternalsExemptions: Array<string | RegExp>;
 };
 
-type OverrideFunction<K extends keyof Overrides> = (config: Overrides[K], appConfig: AppConfigs) => Overrides[K];
+type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R ? (...args: P) => R : never;
+type BoundCreateSingleClientWebpackConfig = OmitFirstArg<typeof createSingleClientWebpackConfig>;
+
+type ClientWebpackAdditionalArgs = {
+    createSingleClientWebpackConfig: BoundCreateSingleClientWebpackConfig;
+}
+
+/**
+ * Дополнительные аргументы, которые будут переданы в функцию оверрайда
+ */
+type OverridesAdditionalArgs = {
+    webpack: ClientWebpackAdditionalArgs;
+    webpackClient: ClientWebpackAdditionalArgs;
+    webpackDev: ClientWebpackAdditionalArgs;
+    webpackClientDev: ClientWebpackAdditionalArgs;
+}
+
+type OverrideFunction<K extends keyof Overrides, AdditionalArgs = K extends keyof OverridesAdditionalArgs ? OverridesAdditionalArgs[K] : undefined> = (
+    config: Overrides[K],
+    appConfig: AppConfigs,
+    additionalArgs: AdditionalArgs
+) => Overrides[K];
 
 export type OverrideFile = {
     [K in keyof Overrides]?: OverrideFunction<K>;
@@ -59,9 +81,14 @@ overrides = appConfigs.overridesPath.map(path => {
  *
  * @param {String|String[]} overridesKey Ключи оверрайда
  * @param {Object} config Конфиг, к которому нужно применить оверрайды
+ * @param args Дополнительные аргументы, которые будут переданы в функцию оверрайда
  * @returns {*}
  */
-function applyOverrides<T extends Overrides[Key], Key extends keyof Overrides>(overridesKey: Key | Key[], config: T): T {
+function applyOverrides<
+    T extends Overrides[Key],
+    Key extends keyof Overrides,
+    Args = Key extends keyof OverridesAdditionalArgs ? OverridesAdditionalArgs[Key] : undefined
+>(overridesKey: Key | Key[], config: T, args?: any): T {
     if (typeof overridesKey === 'string') {
         overridesKey = [overridesKey];
     }
@@ -72,7 +99,7 @@ function applyOverrides<T extends Overrides[Key], Key extends keyof Overrides>(o
                 if (typeof overrideFn !== 'function') {
                     throw new TypeError(`Override ${key} must be a function`)
                 }
-                config = overrideFn(config, appConfigs);
+                config = overrideFn(config, appConfigs, args);
             }
         });
     });

--- a/packages/arui-scripts/src/configs/webpack.client.dev.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.dev.ts
@@ -1,9 +1,10 @@
 import applyOverrides from './util/apply-overrides';
-import { createClientWebpackConfig } from './webpack.client';
+import { createClientWebpackConfig, createSingleClientWebpackConfig } from './webpack.client';
 
 const config = applyOverrides(
     ['webpack', 'webpackClient', 'webpackDev', 'webpackClientDev'],
     createClientWebpackConfig('dev'),
+    { createSingleClientWebpackConfig: createSingleClientWebpackConfig.bind(null, 'dev') },
 );
 
 export default config;

--- a/packages/arui-scripts/src/configs/webpack.client.prod.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.prod.ts
@@ -1,9 +1,10 @@
 import applyOverrides from './util/apply-overrides';
-import { createClientWebpackConfig } from './webpack.client';
+import { createClientWebpackConfig, createSingleClientWebpackConfig } from './webpack.client';
 
 const config = applyOverrides(
     ['webpack', 'webpackClient', 'webpackProd', 'webpackClientProd'],
     createClientWebpackConfig('prod'),
+    { createSingleClientWebpackConfig: createSingleClientWebpackConfig.bind(null, 'prod') }
 );
 
 export default config;

--- a/packages/arui-scripts/src/configs/webpack.client.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.ts
@@ -57,7 +57,7 @@ const clientAssetsPlugin = new AssetsPlugin({
  * @param entry Точка входа, любой валидный вход для webpack
  * @param configName Имя конфигурации, если не указано, то используется имя по умолчанию
  */
-const createSingleClientWebpackConfig = (mode: 'dev' | 'prod', entry: Entry, configName?: string): Configuration => ({
+export const createSingleClientWebpackConfig = (mode: 'dev' | 'prod', entry: Entry, configName?: string): Configuration => ({
     target: 'web',
     mode: mode === 'dev' ? 'development' : 'production',
     devtool: mode === 'dev' ? configs.devSourceMaps : 'source-map',
@@ -430,16 +430,6 @@ const createSingleClientWebpackConfig = (mode: 'dev' | 'prod', entry: Entry, con
     },
 });
 
-// Для того чтобы предоставить пользователям удобный способ создать свой конфиг, мы предоставляем функцию,
-// которая создает конфиг для клиентской части приложения. При этом мы не хотим заставлять пользователей
-// думать про dev/prod режимы, поэтому мы автоматически определяем режим при инициализации и сохраняем его в переменную.
-let lastUsedMode: 'dev' | 'prod' | null = null;
-
 export const createClientWebpackConfig = (mode: 'dev' | 'prod') => {
-    lastUsedMode = mode;
     return createSingleClientWebpackConfig(mode, configs.clientEntry);
-}
-
-export const createSingleWebpackConfig = (entry: Entry, configName: string) => {
-    return createSingleClientWebpackConfig(lastUsedMode || 'dev', entry, configName);
 }

--- a/packages/arui-scripts/src/index.ts
+++ b/packages/arui-scripts/src/index.ts
@@ -4,4 +4,3 @@ export type { AppConfigs, PackageSettings } from './configs/app-configs/types';
 export { prepareFilesForDocker } from './commands/util/docker-build';
 export { getBuildParamsFromArgs } from './commands/util/docker-build';
 export { getDockerBuildCommand } from './commands/util/docker-build';
-export { createSingleWebpackConfig } from './configs/webpack.client';

--- a/packages/arui-scripts/src/index.ts
+++ b/packages/arui-scripts/src/index.ts
@@ -4,3 +4,4 @@ export type { AppConfigs, PackageSettings } from './configs/app-configs/types';
 export { prepareFilesForDocker } from './commands/util/docker-build';
 export { getBuildParamsFromArgs } from './commands/util/docker-build';
 export { getDockerBuildCommand } from './commands/util/docker-build';
+export { createSingleWebpackConfig } from './configs/webpack.client';


### PR DESCRIPTION
Попытка разбить пул-реквест с модулями на чуть более мелкие и понятные части. Этих пул-реквестов будет несколько последовательно.

Этот пр приносит более удобный способ создавать сразу несколько конфигураций для вебпака, функцию `createSingleWebpackConfig`. Она будет использоваться внутри в дальнейшем для того чтобы делать конфигурацию для модулей, но так же может быть использована пользователями для создания своих кастомных конфигураций, которые билдят сразу несколько независимых бандлов из одного проекта