### PR TITLE
fix(postcss): always add custom media variables

### DIFF
--- a/.changeset/moody-ladybugs-fold.md
+++ b/.changeset/moody-ladybugs-fold.md
@@ -1,0 +1,5 @@
+---
+"arui-scripts": patch
+---
+
+Always load custom media variables, remove css vars when keepCssVars set to false

--- a/packages/arui-scripts/src/configs/postcss.config.ts
+++ b/packages/arui-scripts/src/configs/postcss.config.ts
@@ -23,9 +23,9 @@ export const postcssPlugins = [
     'postcss-mixins',
     'postcss-for',
     'postcss-each',
-    ( config.componentsTheme || config.keepCssVars ) && '@csstools/postcss-global-data',
-    config.keepCssVars && 'postcss-custom-media',
-    config.componentsTheme && 'postcss-custom-properties',
+    '@csstools/postcss-global-data',
+    'postcss-custom-media',
+    !config.keepCssVars && 'postcss-custom-properties',
     'postcss-strip-units',
     'postcss-calc',
     'postcss-color-function',
@@ -42,7 +42,7 @@ export const postcssPluginsOptions = {
     },
     '@csstools/postcss-global-data': {
         files: [
-            config.keepCssVars && path.join(__dirname,'mq.css'),
+            path.join(__dirname,'mq.css'),
             config.componentsTheme
         ].filter(Boolean) as string[],
     },

--- a/packages/example/src/components/app.module.css
+++ b/packages/example/src/components/app.module.css
@@ -1,3 +1,20 @@
 .root {
     padding: 10px;
 }
+@media (--tablet) {
+    .root {
+        padding: 15px;
+    }
+}
+
+@media (--desktop) {
+    .root {
+        padding: 30px;
+    }
+}
+
+@media (--mobile) {
+    .root {
+        padding: 5px;
+    }
+}


### PR DESCRIPTION
Исправление некорректной конфигурации для postcss. Видимо тут https://github.com/core-ds/arui-scripts/pull/38/files немного это поломалось, и вылезало сразу два бага:
- Не добавлялись custom-media по дефолту (--tablet, --desktop и тд)
- Не выпиливались css переменные если настройка keepCssVars была выставлена в false