### PR TITLE
Module update

### DIFF
--- a/packages/arui-scripts-modules/src/module-loader/create-module-fetcher.ts
+++ b/packages/arui-scripts-modules/src/module-loader/create-module-fetcher.ts
@@ -36,7 +36,7 @@ export function createModuleFetcher({
     }
 
 
-    return async function getClientModuleResources({ moduleId }): Promise<ModuleResources> {
+    return async function getClientModuleResources({ moduleId, hostAppId }): Promise<ModuleResources> {
         const manifest = await fetchAppManifest(manifestUrl);
         const { mode, ...moduleFiles} = getModuleFiles(manifest, moduleId);
 
@@ -47,6 +47,7 @@ export function createModuleFetcher({
             mountMode: mode,
             moduleState: {
                 baseUrl,
+                hostAppId
             },
         }
     }

--- a/packages/arui-scripts-modules/src/module-loader/types.ts
+++ b/packages/arui-scripts-modules/src/module-loader/types.ts
@@ -37,6 +37,7 @@ export type AruiAppManifest = {
  */
 export type BaseModuleState = {
     baseUrl: string;
+    hostAppId: string;
 };
 /**
  * Ресурсы, которые нужны модулю для запуска

--- a/packages/arui-scripts-server/src/modules/__tests__/create-get-modules-method.tests.ts
+++ b/packages/arui-scripts-server/src/modules/__tests__/create-get-modules-method.tests.ts
@@ -31,7 +31,7 @@ describe('createGetModulesMethod', () => {
                 name: 'module-app-name',
             },
         }));
-        const getModuleState = jest.fn(() => Promise.resolve({ baseUrl: '' }));
+        const getModuleState = jest.fn(() => Promise.resolve({ baseUrl: '', hostAppId: 'test' }));
         const { handler } = createGetModulesMethod({
             test: {
                 mountMode: 'compat',
@@ -47,7 +47,7 @@ describe('createGetModulesMethod', () => {
             moduleVersion: '1.0.0',
             scripts: ['vendor.js', 'main.js'],
             styles: ['vendor.css', 'main.css'],
-            moduleState: { baseUrl: '' },
+            moduleState: { baseUrl: '', hostAppId: 'test' },
             appName: 'module-app-name',
         });
 
@@ -61,7 +61,7 @@ describe('createGetModulesMethod', () => {
             },
         }));
 
-        const getModuleState = jest.fn(() => Promise.resolve({ baseUrl: '' }));
+        const getModuleState = jest.fn(() => Promise.resolve({ baseUrl: '', hostAppId: 'test' }));
         const { handler } = createGetModulesMethod({
             test: {
                 mountMode: 'default',
@@ -77,7 +77,7 @@ describe('createGetModulesMethod', () => {
             moduleVersion: '1.0.0',
             scripts: ['assets/remoteEntry.js'],
             styles: [],
-            moduleState: { baseUrl: '' },
+            moduleState: { baseUrl: '', hostAppId: 'test' },
             appName: 'module-app-name',
         });
 

--- a/packages/arui-scripts/docs/modules.md
+++ b/packages/arui-scripts/docs/modules.md
@@ -150,15 +150,18 @@ export const publicConstant = 3.14;
 ```
 
 #### Compat модуль
-Входная точка compat модуля должна писать в глобальную переменную `window` объект с ключом `{НазваниеМодуля}`.
+Входная точка compat модуля должна писать в глобальную переменную `window` по ключу `{НазваниеМодуля}` функцию, которая будет принимать в качестве аргументов параметры модуля `moduleResources` и возвращать сам модуль в виде любых данных.
 Все поля этого объекта по сути и будут являться модулем, ваши потребители смогут использовать их.
 
 ```ts
 // src/modules/module-compat/index.ts
 
-window.ModuleCompat = {
+window.ModuleCompat = (moduleResources) => {
     doSomething: () => {
-        console.log('Hello from compat module!');
+        console.log('Hello from compat module! My state here: ', moduleResources.moduleState);
+    },
+    getInfo: () => {
+        console.log(`Application: ${moduleResources.appName}. Version: ${moduleResources.moduleVersion}`, 
     },
     publicConstant: 3.14,
     // ...

--- a/packages/example-modules/src/server/index.ts
+++ b/packages/example-modules/src/server/index.ts
@@ -40,6 +40,7 @@ const moduleRouter = createGetModulesExpress({
                 paramFromServer: 'This can be any data from server',
                 asyncData: 'It can be constructed from async data, so you may perform some service calls here',
                 baseUrl: 'http://localhost:8082',
+                hostAppId: getResourcesRequest.hostAppId,
                 stuffFromClient: getResourcesRequest.params
             });
         },
@@ -47,10 +48,11 @@ const moduleRouter = createGetModulesExpress({
     'ServerStateModule': {
         mountMode: 'default',
         version: '1.0.0',
-        getModuleState: async () => ({
+        getModuleState: async (getResourcesRequest) => ({
             paramFromServer: 'This can be any data from server',
             asyncData: 'It can be constructed from async data, so you may perform some service calls here',
             baseUrl: 'http://localhost:8082',
+            hostAppId: getResourcesRequest.hostAppId,
         }),
     },
 });


### PR DESCRIPTION
1. Предлагается сделать так, чтобы немонтируемые модули были по умолчанию функциями высшего порядка, в которые передаются параметры модуля, которые сейчас просто возвращаются из хука. Хочется иметь параметры модуля внутри самого модуля, не заставляя при этом вызывать потребителя модуль с этими параметрами лишний раз.  Использовать или не использовать эти параметры определяет сам модуль, а там, где необходимо, поставщик модулей сможет вернуть эти параметры из HOF.
2. Небольшое изменение касательно наполнения параметров вызова функции. При загрузке модуля мы получаем hostAppId, но потом теряем его из виду, и по идее можем использовать только на стороне серверных модулей, но если он нужен в модулях без серверного стейта, то достать его можно только повторно передав в модуль через приложение-потребитель. Кажется, имеет смысл возвращать его в moduleState в любом случае. 