### PR TITLE
fix(module): postcss prefix for css root variables

### DIFF
--- a/.changeset/afraid-kids-sneeze.md
+++ b/.changeset/afraid-kids-sneeze.md
@@ -1,0 +1,5 @@
+---
+"arui-scripts": patch
+---
+
+Fix postcss prefix for modules

--- a/packages/arui-scripts/src/configs/modules.ts
+++ b/packages/arui-scripts/src/configs/modules.ts
@@ -81,9 +81,17 @@ function addPrefixCssRule(rule: webpack.RuleSetRule | undefined, prefix: string)
         return;
     }
 
+    function transform (incomingPrefix: string, selector: string, prefixedSelector: string) {
+        if (selector === ':root') {
+            return incomingPrefix
+        }
+
+        return prefixedSelector
+    }
+
     postCssLoader.options.postcssOptions.plugins = [
         ...postCssLoader.options.postcssOptions.plugins,
-        cssPrefix({ prefix }),
+        cssPrefix({ prefix, transform }),
     ];
 }
 


### PR DESCRIPTION
Небольшое изменение сборки css для модулей. Раньше, если флаг keepCssVars был равен true, css переменные которые не используются в хост-проекте не добавлялись в бандл, а в модуле эти переменные добавлялись с префиксом, например так:
```
.some-module-prefix :root {
    --some-variable: 100500px;
}
```
Такой синтаксис не работает из-за чего в браузере в модулях ломалась верстка.
Чтобы этого избежать была добавлена функция transform, которая меняет объявление переменных. Теперь переменные будут объявляться в контексте префикса вот так:
```
.some-module-prefix {
    --some-variable: 100500px;
}
```
В таком случае данные переменные будут доступны только внутри класса `.some-module-prefix` и не повлияют на стили хост-приложения.