### PR TITLE
fix(dev-server-cors): add response for options method

### DIFF
--- a/.changeset/many-tables-compare.md
+++ b/.changeset/many-tables-compare.md
@@ -1,0 +1,5 @@
+---
+"arui-scripts": patch
+---
+
+Add 200 response for OPTIONS request when devServerCors option is enabled

--- a/packages/arui-scripts/src/configs/dev-server.ts
+++ b/packages/arui-scripts/src/configs/dev-server.ts
@@ -28,14 +28,21 @@ const devServerConfig = applyOverrides('devServer', {
 
                 return null;
             },
-            // Для дев режима, когда мы используем в качестве соурсмапов что-то, основанное на eval - нужно
-            // разрешить браузеру исполнять наш код, даже когда content-security-policy приложения не позволяет этого делать.
-            ...(configs.devSourceMaps.includes('eval') ? {
+            ...(configs.devSourceMaps.includes('eval') || configs.devServerCors ? {
                 onProxyRes: (proxyRes: http.IncomingMessage) => {
-                    const cspHeader = proxyRes.headers['content-security-policy'];
-                    if (typeof cspHeader === 'string' && !cspHeader.includes('unsafe-eval')) {
-                        proxyRes.headers['content-security-policy'] = cspHeader
-                            .replace(/script-src/, 'script-src \'unsafe-eval\'');
+                    // Для дев режима, когда мы используем в качестве соурсмапов что-то, основанное на eval - нужно
+                    // разрешить браузеру исполнять наш код, даже когда content-security-policy приложения не позволяет этого делать.
+                    if (configs.devSourceMaps.includes('eval')) {
+                        const cspHeader = proxyRes.headers['content-security-policy'];
+                        if (typeof cspHeader === 'string' && !cspHeader.includes('unsafe-eval')) {
+                            proxyRes.headers['content-security-policy'] = cspHeader
+                                .replace(/script-src/, 'script-src \'unsafe-eval\'');
+                        }
+                    }
+                    // если включен devServerCors, то нужно принудительно менять статус ответа на 200, чтобы
+                    // браузер не отклонял ответы с CORS
+                    if (configs.devServerCors && proxyRes.method === 'OPTIONS') {
+                        proxyRes.statusCode = 200;
                     }
                 },
             } : {}),


### PR DESCRIPTION
Добавлено принудительное проставление 200 статуса ответа на OPTIONS запросы если включена настройка `devServerCors`. Без этого на стороне потребителей приходилось рукамии добавлять обработчик OPTIONS запросов