### PR TITLE
fix(compat-modules): correctly add css prefixes for nested selectors

### DIFF
--- a/.changeset/sour-walls-march.md
+++ b/.changeset/sour-walls-march.md
@@ -1,0 +1,5 @@
+---
+"arui-scripts": patch
+---
+
+Correctly add prefix for module css selector when css has nested rules

--- a/packages/arui-scripts/package.json
+++ b/packages/arui-scripts/package.json
@@ -136,7 +136,7 @@
         "@types/webpack-dev-server": "^4.0.0",
         "@types/webpack-manifest-plugin": "3.0.3",
         "@types/webpack-node-externals": "^3.0.0",
-        "postcss": "^7.0.0 || ^8.0.1",
+        "postcss": "^8.4.28",
         "semantic-release": "^17.3.4",
         "type-fest": "2.0.0",
         "typescript": "4.9.5"

--- a/packages/arui-scripts/src/configs/modules.ts
+++ b/packages/arui-scripts/src/configs/modules.ts
@@ -81,9 +81,16 @@ function addPrefixCssRule(rule: webpack.RuleSetRule | undefined, prefix: string)
         return;
     }
 
-    function transform (incomingPrefix: string, selector: string, prefixedSelector: string) {
+    function transform (incomingPrefix: string, selector: string, prefixedSelector: string, file: string, rule: any) {
         if (selector === ':root') {
+            // :root фактически должен заменяться на название класса модуля
             return incomingPrefix
+        }
+
+        if (rule.parent.parent && rule.parent.type !== 'atrule') {
+            // если у селектора родителем явлеется не root - значит он часть нестинга и его не надо префиксить
+            // исключение - если родитель @-правило, типа @media
+            return selector;
         }
 
         return prefixedSelector
@@ -91,7 +98,7 @@ function addPrefixCssRule(rule: webpack.RuleSetRule | undefined, prefix: string)
 
     postCssLoader.options.postcssOptions.plugins = [
         ...postCssLoader.options.postcssOptions.plugins,
-        cssPrefix({ prefix, transform }),
+        cssPrefix({ prefix, transform: transform as any }),
     ];
 }
 

--- a/packages/example-modules/src/modules/module-compat/index.ts
+++ b/packages/example-modules/src/modules/module-compat/index.ts
@@ -12,6 +12,10 @@ const mountModule: ModuleMountFunction<any, any> = (targetNode, runParams) => {
     <div class="primary">
       У виджета могут быть свои стили, которые автоматически будут изолированы от других стилей на странице.
       Единственное условие - виджет сам должен добавлять class="module-{ID виджета}" к корневому элементу.
+
+      <div class="primary__footer">
+        Этот текст должен быть синего цвета
+      </div>
     </div>
   </div>`;
     }

--- a/packages/example-modules/src/modules/module-compat/styles.css
+++ b/packages/example-modules/src/modules/module-compat/styles.css
@@ -1,3 +1,11 @@
 .primary {
     color: red;
+
+    &__footer {
+        color: blue;
+    }
+
+    @media (min-width: 1024px) {
+        color: coral;
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6217,7 +6217,7 @@ __metadata:
     mini-svg-data-uri: ^1.4.4
     null-loader: 0.1.1
     pnp-webpack-plugin: 1.7.0
-    postcss: ^7.0.0 || ^8.0.1
+    postcss: ^8.4.28
     postcss-calc: ^9.0.0
     postcss-color-function: ^4.0.0
     postcss-color-mod-function: ^3.0.0
@@ -18104,7 +18104,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^7.0.0 || ^8.0.1, postcss@npm:^8.2.8, postcss@npm:^8.3.5":
+"postcss@npm:^7.0.17, postcss@npm:^7.0.2, postcss@npm:^7.0.5":
+  version: 7.0.32
+  resolution: "postcss@npm:7.0.32"
+  dependencies:
+    chalk: ^2.4.2
+    source-map: ^0.6.1
+    supports-color: ^6.1.0
+  checksum: 3bc2ac6508c97559077bd24f341908d5b86a50b76164c87d4224af94248ca329e28fc5292fff9cc3fec503325cac40094a6fbf7ef1bd1a3e94aefa93031834f0
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.2.8, postcss@npm:^8.3.5":
   version: 8.4.24
   resolution: "postcss@npm:8.4.24"
   dependencies:
@@ -18115,14 +18126,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^7.0.17, postcss@npm:^7.0.2, postcss@npm:^7.0.5":
-  version: 7.0.32
-  resolution: "postcss@npm:7.0.32"
+"postcss@npm:^8.4.28":
+  version: 8.4.28
+  resolution: "postcss@npm:8.4.28"
   dependencies:
-    chalk: ^2.4.2
-    source-map: ^0.6.1
-    supports-color: ^6.1.0
-  checksum: 3bc2ac6508c97559077bd24f341908d5b86a50b76164c87d4224af94248ca329e28fc5292fff9cc3fec503325cac40094a6fbf7ef1bd1a3e94aefa93031834f0
+    nanoid: ^3.3.6
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: f605c24a36f7e400bad379735fbfc893ccb8d293ad6d419bb824db77cdcb69f43d614ef35f9f7091f32ca588d130ec60dbcf53b366e6bf88a8a64bbeb3c05f6d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Обновление postcss изменило то, как работает postcss-prefix-selector. Теперь он стал запускаться и для nested селекторов, что приводило к генерации некорректного css.

Например для такого css:
```css
.foo {
  color: red;
  &__bar {
    color: blue;
  }
}
```

генерировался код:
```css
.module-example .foo {
  color: red;
}
.module-example .module-example .foo__bar {
  color: blue;
}
```

Фиксим это
