### PR TITLE
test(example-modules): add some validation for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     },
     "husky": {
         "hooks": {
-            "pre-commit": "turbo run build lint test",
+            "pre-commit": "yarn test",
             "commit-msg": "yarn commitlint -E HUSKY_GIT_PARAMS"
         }
     },
     "scripts": {
-        "publish-packages": "turbo run build lint test && changeset version && changeset publish",
-        "build": "turbo run build"
+        "publish-packages": "yarn test && changeset version && changeset publish",
+        "build": "turbo run build",
+        "test": "turbo run build lint test validate"
     }
 }

--- a/packages/example-modules/arui-scripts.overrides.ts
+++ b/packages/example-modules/arui-scripts.overrides.ts
@@ -1,18 +1,6 @@
 import { OverrideFile } from "arui-scripts";
 
 const overrides: OverrideFile = {
-    webpackClient: (config, appConfig, { createSingleClientWebpackConfig }) => {
-        const workerConfig = createSingleClientWebpackConfig(
-            { worker: './src/worker.ts' },
-            'worker',
-        );
-        workerConfig.output.filename = 'worker.js';
-
-        return [
-            config,
-            workerConfig,
-        ];
-    },
     webpackClientProd: (config) => {
         const allConfigs = Array.isArray(config) ? config : [config];
 

--- a/packages/example-modules/jest.config.validate-build.js
+++ b/packages/example-modules/jest.config.validate-build.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+    testRegex: '.*\\.spec\\.ts$',
+    transform: {
+        "^.+\\.tsx?$": require.resolve('ts-jest'),
+    }
+};

--- a/packages/example-modules/package.json
+++ b/packages/example-modules/package.json
@@ -4,13 +4,11 @@
     "private": true,
     "scripts": {
         "build": "arui-scripts build",
-        "start": "NODE_ENV=localhost arui-scripts start"
+        "start": "NODE_ENV=localhost arui-scripts start",
+        "validate": "jest \"validate-build/*\" --config jest.config.validate-build.js"
     },
     "jest": {
-        "preset": "arui-scripts",
-        "setupFiles": [
-            "<rootDir>/__tests__/setup.js"
-        ]
+        "preset": "arui-scripts"
     },
     "dependencies": {
         "@alfalab/scripts-modules": "workspace:*",

--- a/packages/example-modules/validate-build/__snapshots__/build.spec.ts.snap
+++ b/packages/example-modules/validate-build/__snapshots__/build.spec.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modules should create valid css for ModuleCompat 1`] = `
+".module-ModuleCompat .primary{
+    color:red;
+}
+
+    .module-ModuleCompat .primary__footer{
+        color:blue;
+    }
+
+    @media (min-width: 1024px){.module-ModuleCompat .primary{
+        color:coral
+}
+    }
+
+"
+`;

--- a/packages/example-modules/validate-build/build.spec.ts
+++ b/packages/example-modules/validate-build/build.spec.ts
@@ -1,0 +1,131 @@
+import fs from 'fs';
+import path from 'path';
+
+const BUILD_PATH = path.join(__dirname, '../.build');
+
+async function fileExists(filePath: string) {
+    try {
+        const res = await fs.promises.stat(filePath);
+
+        return res.isFile();
+    } catch (e) {
+        return false;
+    }
+}
+
+describe('assets-manifest', () => {
+    it('should have client assets manifest', async () => {
+        const manifestPath = path.join(BUILD_PATH, 'assets/webpack-assets.json');
+
+        expect(await fileExists(manifestPath)).toBe(true);
+    });
+
+    it('should have server assets manifest', async () => {
+        const manifestPath = path.join(BUILD_PATH, 'webpack-assets.json');
+
+        expect(await fileExists(manifestPath)).toBe(true);
+    });
+
+    it('should contain list of all assets', async () => {
+        const manifestPath = path.join(BUILD_PATH, 'webpack-assets.json');
+        const manifest = JSON.parse(await fs.promises.readFile(manifestPath, 'utf-8'));
+
+        expect(manifest).toMatchObject({
+            FactoryModuleCompat: {
+                js: expect.any(String),
+            },
+            Module: {
+                mode: 'default',
+                js: expect.any(String),
+            },
+            ServerStateFactoryModule: {
+                mode: 'default',
+                js: expect.any(String),
+            },
+            ModuleAbstract: {
+                mode: 'default',
+                js: expect.any(String),
+            },
+            ServerStateModuleCompat: {
+                js: expect.any(String),
+            },
+            ModuleAbstractCompat: {
+                js: expect.any(String),
+            },
+            ModuleCompat: {
+                js: expect.any(String),
+                css: expect.any(String),
+            },
+            main: {
+                js: expect.any(String),
+            },
+            __metadata__: {
+                version: expect.any(String),
+                name: 'example_modules',
+            },
+        });
+    });
+});
+
+describe('server', () => {
+    it('should have server entry', async () => {
+        const serverEntryPath = path.join(BUILD_PATH, 'server.js');
+
+        expect(await fileExists(serverEntryPath)).toBe(true);
+    });
+});
+
+describe('client', () => {
+    it('should create client entry', async () => {
+        const assetsManifest = JSON.parse(
+            await fs.promises.readFile(path.join(BUILD_PATH, 'assets/webpack-assets.json'), 'utf-8'),
+        );
+
+        const mainJsPath = path.join(BUILD_PATH, assetsManifest.main.js);
+
+        expect(await fileExists(mainJsPath)).toBe(true);
+    });
+});
+
+describe('modules', () => {
+    const modules = [
+        'Module',
+        'ModuleAbstract',
+        'ModuleCompat',
+        'ModuleAbstractCompat',
+        'FactoryModuleCompat',
+        'ServerStateModuleCompat',
+        'ServerStateFactoryModule',
+    ];
+
+    it.each(modules)('should create module %s entry point', async (moduleName) => {
+        const assetsManifest = JSON.parse(
+            await fs.promises.readFile(path.join(BUILD_PATH, 'assets/webpack-assets.json'), 'utf-8'),
+        );
+
+        const moduleJsPath = path.join(BUILD_PATH, assetsManifest[moduleName].js);
+        expect(await fileExists(moduleJsPath)).toBe(true);
+
+        if (assetsManifest[moduleName].css) {
+            const moduleCssPath = path.join(BUILD_PATH, assetsManifest[moduleName].css);
+            expect(await fileExists(moduleCssPath)).toBe(true);
+        }
+    });
+
+    it('should create entry point for MF modules', async () => {
+        const remoteEntryPath = path.join(BUILD_PATH, 'assets/remoteEntry.js');
+
+        expect(await fileExists(remoteEntryPath)).toBe(true);
+    });
+
+    it('should create valid css for ModuleCompat', async () => {
+        const assetsManifest = JSON.parse(
+            await fs.promises.readFile(path.join(BUILD_PATH, 'assets/webpack-assets.json'), 'utf-8'),
+        );
+
+        const moduleCssPath = path.join(BUILD_PATH, assetsManifest.ModuleCompat.css);
+
+        expect(await fileExists(moduleCssPath)).toBe(true);
+        expect(await fs.promises.readFile(moduleCssPath, 'utf-8')).toMatchSnapshot();
+    })
+});

--- a/packages/example-modules/validate-build/tsconfig.json
+++ b/packages/example-modules/validate-build/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "arui-scripts/tsconfig.json",
+    "include": [
+        "**/*.ts"
+    ],
+    "compilerOptions": {
+        "baseUrl": "./",
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true
+    }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,9 @@
         "test": {
             "dependsOn": ["^build"]
         },
-        "lint": {}
+        "lint": {},
+        "validate": {
+            "dependsOn": ["build"]
+        }
     }
 }


### PR DESCRIPTION
Добавлен простенький механизм валидации билда для проекта example-modules.
Проверяет что после билда создаются все нужные файлы + что файлы выглядят так, как надо.
Пока не уверен что это реально полезные тесты, которые помогут находить проблемы, поэтому проверяют они очень немногое.

Эти тесты теперь зависят от того, чтобы проект был собран перед тем как тесты запустились. Это конечно плохо, но в целом решается просто запуском всего и вся через turbo, в котором все эти зависимости описаны