### PR TITLE
feat(*): ignore css order to prevent conflicts

### DIFF
--- a/.changeset/twelve-monkeys-collect.md
+++ b/.changeset/twelve-monkeys-collect.md
@@ -1,0 +1,5 @@
+---
+"arui-scripts": patch
+---
+
+ignore css order to prevent conflicts

--- a/packages/arui-scripts/src/configs/webpack.client.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.ts
@@ -361,6 +361,7 @@ export const createSingleClientWebpackConfig = (mode: 'dev' | 'prod', entry: Ent
             ),
         }),
         new MiniCssExtractPlugin({
+            ignoreOrder: true,
             filename: mode === 'dev' ? '[name].css' : '[name].[contenthash:8].css',
             chunkFilename: mode === 'dev' ? '[id].css' : '[name].[contenthash:8].chunk.css',
         }),


### PR DESCRIPTION
При сборке с использованием lazy-импортов выводятся предупреждения:
```
Conflicting order. Following module has been added:
 * ...gutters.css
despite it was not able to fulfill desired ordering with these modules:
 * ...inverted.css
   - couldn't fulfill desired order of chunk group(s) root-page
   - while fulfilling desired order of chunk group(s) settings-page
```

Проблема кроется в mini-css-extract-plugin и решается добавлением свойства [ignoreOrder](https://github.com/facebook/create-react-app/issues/5372#issuecomment-995632657)