### PR TITLE
Feat/disable dev webpack typecheck

### DIFF
--- a/.changeset/popular-timers-wave.md
+++ b/.changeset/popular-timers-wave.md
@@ -1,0 +1,22 @@
+---
+"arui-scripts": minor
+---
+
+
+## Текущая реализация нацелена на снятие лишней нагрузки в режиме разработки при проверки типов.
+
+#### disableDevWebpackTypecheck=false, команда start:
+    1. В конфиге для клиента запускается ForkTsCheckerWebpackPlugin.
+    2. В конфигах, сделанных через createSingle - не запускается.
+    
+#### disableDevWebpackTypecheck=false, команда build:
+    1. В конфиге для клиента запускается ForkTsCheckerWebpackPlugin.
+    2. В конфигах, сделанных через createSingle - не запускается.
+
+#### disableDevWebpackTypecheck=true, команда start:
+    1. Запускается runCompilers c TSC_WATCH_COMMAND.
+    2. В вебпаке для клиента и сервера ForkTsCheckerWebpackPlugin не запускается.
+
+#### disableDevWebpackTypecheck=true, команда build:
+    1. В конфиге для клиента запускается ForkTsCheckerWebpackPlugin.
+    2. В конфигах, сделанных через createSingle - не запускается.

--- a/packages/arui-scripts/docs/settings.md
+++ b/packages/arui-scripts/docs/settings.md
@@ -238,3 +238,7 @@ const settings = {
 
 #### compatModules
 Позволяет настроить работу с `compat` модулями. По умолчанию `{}`. Подробнее в разделе [модули](modules.md).
+
+#### disableDevWebpackTypecheck
+Позволяет настроить проверку типов для клиентского кода и серверный код в режиме разработки. 
+Если `true`, то для проверки типов используется `tsc --watch --noEmit --project tsconfig.json --skipLibCheck`, вместо `ForkTsCheckerWebpackPlugin`. По умолчанию `false`.

--- a/packages/arui-scripts/src/commands/start/index.ts
+++ b/packages/arui-scripts/src/commands/start/index.ts
@@ -1,8 +1,25 @@
-import { runCompilers } from '../util/run-compilers';
+import configs from "../../configs/app-configs";
+import { runCompilers } from "../util/run-compilers";
 
-process.env.BROWSERSLIST_CONFIG = process.env.BROWSERSLIST_CONFIG || require.resolve('../../../.browserslistrc');
+process.env.BROWSERSLIST_CONFIG =
+    process.env.BROWSERSLIST_CONFIG ||
+    require.resolve("../../../.browserslistrc");
 
-runCompilers([
-    require.resolve('./client'),
-    require.resolve('./server'),
-]);
+if (configs.tsconfig && configs.disableDevWebpackTypecheck) {
+    const TSC_WATCH_COMMAND = [
+        require.resolve("typescript/lib/tsc.js"),
+        "--watch",
+        "--noEmit",
+        "--project",
+        configs.tsconfig,
+        "--skipLibCheck",
+    ];
+
+    runCompilers([
+        require.resolve("./client"),
+        require.resolve("./server"),
+        TSC_WATCH_COMMAND,
+    ]);
+} else {
+    runCompilers([require.resolve("./client"), require.resolve("./server")]);
+}

--- a/packages/arui-scripts/src/configs/app-configs/get-defaults.ts
+++ b/packages/arui-scripts/src/configs/app-configs/get-defaults.ts
@@ -43,6 +43,7 @@ export function getDefaultAppConfig(): AppConfigs {
         useTscLoader: false,
         webpack4Compatibility: false,
         installServerSourceMaps: false,
+        disableDevWebpackTypecheck:false,
 
         // image processing
         dataUrlMaxSize: 1536,

--- a/packages/arui-scripts/src/configs/app-configs/types.ts
+++ b/packages/arui-scripts/src/configs/app-configs/types.ts
@@ -40,6 +40,7 @@ export type AppConfigs = {
     useTscLoader: boolean;
     webpack4Compatibility: boolean;
     installServerSourceMaps: boolean;
+    disableDevWebpackTypecheck: boolean;
 
     // image processing
     dataUrlMaxSize?: number;

--- a/packages/arui-scripts/src/configs/webpack.client.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.ts
@@ -394,7 +394,7 @@ export const createSingleClientWebpackConfig = (mode: 'dev' | 'prod', entry: Ent
             filename: mode === 'dev' ? '[name].css' : '[name].[contenthash:8].css',
             chunkFilename: mode === 'dev' ? '[id].css' : '[name].[contenthash:8].chunk.css',
         }),
-        configs.tsconfig !== null && new ForkTsCheckerWebpackPlugin(),
+        (mode === "prod" || !configs.disableDevWebpackTypecheck) && configs.tsconfig !== null && new ForkTsCheckerWebpackPlugin(),
         // moment.js очень большая библиотека, которая включает в себя массу локализаций, которые мы не используем.
         // Поэтому мы их просто игнорируем, чтобы не включать в сборку.
         // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack

--- a/packages/arui-scripts/src/configs/webpack.server.ts
+++ b/packages/arui-scripts/src/configs/webpack.server.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import webpack, { Configuration } from 'webpack';
 
 import nodeExternals from 'webpack-node-externals';
-import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import getCSSModuleLocalIdent from 'react-dev-utils/getCSSModuleLocalIdent';
 
@@ -205,7 +204,6 @@ export const createServerConfig = (mode: 'dev' | 'prod'): Configuration => ({
             raw: true,
             entryOnly: false
         }),
-        configs.tsconfig !== null && new ForkTsCheckerWebpackPlugin(),
 
         // dev plugins:
         mode === 'dev' && (configs.useServerHMR


### PR DESCRIPTION
## Текущая реализация нацелена на снятие лишней нагрузки в режиме разработки при проверки типов.

#### disableDevWebpackTypecheck=false, команда start:
    1. В конфиге для клиента запускается ForkTsCheckerWebpackPlugin.
    2. В конфигах, сделанных через createSingle - не запускается.
    
#### disableDevWebpackTypecheck=false, команда build:
    1. В конфиге для клиента запускается ForkTsCheckerWebpackPlugin.
    2. В конфигах, сделанных через createSingle - не запускается.

#### disableDevWebpackTypecheck=true, команда start:
    1. Запускается runCompilers c TSC_WATCH_COMMAND.
    2. В вебпаке для клиента и сервера ForkTsCheckerWebpackPlugin не запускается.

#### disableDevWebpackTypecheck=true, команда build:
    1. В конфиге для клиента запускается ForkTsCheckerWebpackPlugin.
    2. В конфигах, сделанных через createSingle - не запускается.