### PR TITLE
docs(modules): add misising method, fix incorrect types

### DIFF
--- a/.changeset/curvy-fireants-tell.md
+++ b/.changeset/curvy-fireants-tell.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/scripts-modules': minor
+---
+
+Добавлен экспорт функции executeModuleFactory для использования модулей фабрик вне react-хуков

--- a/packages/arui-scripts-modules/src/module-loader/index.ts
+++ b/packages/arui-scripts-modules/src/module-loader/index.ts
@@ -8,4 +8,4 @@ export { getServerStateModuleFetcherParams } from './get-server-state-module-fet
 
 export { useModuleLoader } from './hooks/use-module-loader';
 export { useModuleMounter } from './hooks/use-module-mounter';
-export { useModuleFactory } from './hooks/use-module-factory';
+export { useModuleFactory, executeModuleFactory } from './hooks/use-module-factory';

--- a/packages/arui-scripts-modules/src/module-loader/types.ts
+++ b/packages/arui-scripts-modules/src/module-loader/types.ts
@@ -66,7 +66,7 @@ export type ModuleResources<ModuleState extends BaseModuleState = BaseModuleStat
     moduleState: ModuleState;
 };
 
-type LoaderResult<ModuleExportType> = {
+export type LoaderResult<ModuleExportType> = {
     unmount: () => void;
     module: ModuleExportType;
     moduleResources: ModuleResources;


### PR DESCRIPTION
Добавлен экспорт функции executeModuleFactory для использования модулей фабрик вне react-хуков.

Чутка поправлена документация, в ней использовались некорректные типы состояния загрузки