### PR TITLE
добавление findPlugin хелпера

### DIFF
--- a/.changeset/famous-hounds-compete.md
+++ b/.changeset/famous-hounds-compete.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': minor
+---
+
+добавление findPlugin хелпера для overrides-файла

--- a/packages/arui-scripts/.eslintrc.js
+++ b/packages/arui-scripts/.eslintrc.js
@@ -9,5 +9,7 @@ module.exports = {
     rules: {
         'import/no-default-export': 'warn',
         'import/no-named-as-default': 'warn',
+        // чтобы могли использовать for и генераторы
+        'no-restricted-syntax': 'off',
     },
 };

--- a/packages/arui-scripts/src/configs/util/__tests__/find-plugin.tests.ts
+++ b/packages/arui-scripts/src/configs/util/__tests__/find-plugin.tests.ts
@@ -1,0 +1,120 @@
+import { createSingleClientWebpackConfig } from '../../webpack.client';
+import { createServerConfig } from '../../webpack.server';
+import { findPlugin } from '../find-plugin';
+
+const getPlugins = (
+    plugins: any,
+    name: string,
+    property: (...props: any[]) => Record<string, unknown>,
+) =>
+    plugins.map((plugin: unknown) => {
+        if (plugin?.constructor.name === name) {
+            const typedPlugin = plugin as any;
+
+            return {
+                ...typedPlugin,
+                ...property(typedPlugin),
+            };
+        }
+
+        return plugin;
+    });
+
+describe('override plugins with findPlugin', () => {
+    describe("client's findPlugin", () => {
+        it('should return original client dev config with modified MiniCssExtractPlugin: options.ignoreOrder = false', () => {
+            const devConfig = createSingleClientWebpackConfig('dev', './index.ts');
+
+            const [MiniCssExtractPlugin] = findPlugin<'client'>()(
+                devConfig,
+                'MiniCssExtractPlugin',
+            );
+
+            MiniCssExtractPlugin.options.ignoreOrder = false;
+
+            expect(devConfig).toMatchObject<typeof devConfig>({
+                ...devConfig,
+                plugins: getPlugins(devConfig.plugins, 'MiniCssExtractPlugin', (pluginOptions) => ({
+                    ...pluginOptions,
+                    options: {
+                        ...pluginOptions.options,
+                        ignoreOrder: false,
+                    },
+                })),
+            });
+        });
+
+        it('should return original client prod config with modified WebpackManifestPlugin: options.fileName = super-app-manifest.json', () => {
+            const prodConfig = createSingleClientWebpackConfig('prod', './index.ts');
+
+            const [WebpackManifestPlugin] = findPlugin<'client'>()(
+                prodConfig,
+                'WebpackManifestPlugin',
+            );
+
+            WebpackManifestPlugin.options = {
+                ...WebpackManifestPlugin.options,
+                fileName: 'super-app-manifest.json',
+            };
+
+            expect(prodConfig).toMatchObject<typeof prodConfig>({
+                ...prodConfig,
+                plugins: getPlugins(
+                    prodConfig.plugins,
+                    'WebpackManifestPlugin',
+                    (pluginOptions) => ({
+                        ...pluginOptions,
+                        options: {
+                            ...pluginOptions.options,
+                            fileName: 'super-app-manifest.json',
+                        },
+                    }),
+                ),
+            });
+        });
+    });
+
+    describe("server's findPlugin", () => {
+        it('should return original server dev config with modified BannerPlugin: options.banner = "sell garage"', () => {
+            const devConfig = createServerConfig('dev');
+
+            const [BannerPlugin] = findPlugin<'server'>()(devConfig, 'BannerPlugin');
+
+            BannerPlugin.options.banner = 'sell garage';
+
+            expect(devConfig).toMatchObject<typeof devConfig>({
+                ...devConfig,
+                plugins: getPlugins(devConfig.plugins, 'BannerPlugin', (pluginOptions) => ({
+                    ...pluginOptions,
+                    options: {
+                        ...pluginOptions.options,
+                        banner: 'sell garage',
+                    },
+                })),
+            });
+        });
+
+        it('should return original server dev config with modified WatchMissingNodeModulesPlugin: nodeModulesPath = ./123', () => {
+            const devConfig = createServerConfig('dev');
+
+            const [WatchMissingNodeModulesPlugin] = findPlugin<'server'>()(
+                devConfig,
+                'WatchMissingNodeModulesPlugin',
+            );
+
+            WatchMissingNodeModulesPlugin.nodeModulesPath = './123';
+
+            expect(devConfig).toMatchObject<typeof devConfig>({
+                ...devConfig,
+                plugins: getPlugins(
+                    devConfig.plugins,
+                    'WatchMissingNodeModulesPlugin',
+                    (pluginOptions) => ({
+                        ...pluginOptions,
+                        nodeModulesPath: './123',
+                    }),
+                ),
+            });
+        });
+    });
+});

--- a/packages/arui-scripts/src/configs/util/apply-overrides.ts
+++ b/packages/arui-scripts/src/configs/util/apply-overrides.ts
@@ -7,6 +7,7 @@ import { AppContextWithConfigs } from '../app-configs/types';
 import { createSingleClientWebpackConfig } from '../webpack.client';
 
 import { findLoader } from './find-loader';
+import { findPlugin } from './find-plugin';
 
 type Overrides = {
     webpack: WebpackConfiguration | WebpackConfiguration[];
@@ -43,6 +44,12 @@ type BoundCreateSingleClientWebpackConfig = OmitFirstArg<typeof createSingleClie
 type ClientWebpackAdditionalArgs = {
     createSingleClientWebpackConfig: BoundCreateSingleClientWebpackConfig;
     findLoader: typeof findLoader;
+    findPlugin: ReturnType<typeof findPlugin<'client'>>
+};
+
+type ServerWebpackAdditionalArgs = {
+    findLoader: typeof findLoader;
+    findPlugin: ReturnType<typeof findPlugin<'server'>>;
 };
 
 /**
@@ -53,6 +60,8 @@ type OverridesAdditionalArgs = {
     webpackClient: ClientWebpackAdditionalArgs;
     webpackDev: ClientWebpackAdditionalArgs;
     webpackClientDev: ClientWebpackAdditionalArgs;
+    webpackServer: ServerWebpackAdditionalArgs;
+    webpackServerDev: ServerWebpackAdditionalArgs;
 };
 
 type OverrideFunction<

--- a/packages/arui-scripts/src/configs/util/find-plugin.ts
+++ b/packages/arui-scripts/src/configs/util/find-plugin.ts
@@ -1,0 +1,118 @@
+import { Cluster } from 'cluster';
+
+import { ReactRefreshPluginOptions } from '@pmmmwh/react-refresh-webpack-plugin/types/lib/types';
+import AssetsPlugin from 'assets-webpack-plugin';
+import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin';
+import CompressionPlugin from 'compression-webpack-plugin';
+import { ForkTsCheckerWebpackPluginOptions } from 'fork-ts-checker-webpack-plugin/lib/ForkTsCheckerWebpackPluginOptions';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import { RunScriptWebpackPlugin } from 'run-script-webpack-plugin';
+import webpack from 'webpack';
+import { WebpackDeduplicationPlugin } from 'webpack-deduplication-plugin';
+import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
+
+/*
+    вариации плагинов клиента
+    Сюда не попали:
+        1. ModuleFederationPlugin
+*/
+type PluginsListClient = {
+    AssetsWebpackPlugin: {
+        options: AssetsPlugin.Options;
+    };
+    DefinePlugin: {
+        definitions: ConstructorParameters<typeof webpack.DefinePlugin>[number];
+    };
+    MiniCssExtractPlugin: {
+        options: MiniCssExtractPlugin.PluginOptions;
+        runtimeOptions: MiniCssExtractPlugin.RuntimeOptions;
+    };
+    ForkTsCheckerWebpackPlugin: {
+        options: ForkTsCheckerWebpackPluginOptions;
+    };
+    IgnorePlugin: {
+        options:
+            | {
+                  contextRegExp?: RegExp;
+                  resourceRegExp: RegExp;
+              }
+            | {
+                  checkResource: (resource: string, context: string) => boolean;
+              };
+        checkIgnore: (resolveData: webpack.ResolveData) => undefined | false;
+    };
+    WebpackDeduplicationPlugin: WebpackDeduplicationPlugin;
+    ReactRefreshPlugin: {
+        options: ReactRefreshPluginOptions;
+    };
+    CaseSensitivePathsPlugin: {
+        options: CaseSensitivePathsPlugin.Options;
+        logger: {
+            [K in keyof Console]: Console[K];
+        };
+    };
+    WebpackManifestPlugin: {
+        options: ConstructorParameters<typeof WebpackManifestPlugin>[number];
+    };
+    CompressionPlugin: {
+        options: ConstructorParameters<typeof CompressionPlugin>[number];
+    };
+    NormalModuleReplacementPlugin: webpack.NormalModuleReplacementPlugin;
+};
+
+/*
+    вариации плагинов сервера
+    сюда не попали:
+        1. HotModuleReplacementPlugin
+        2. NoEmitOnErrorsPlugin
+ */
+type PluginsListServer = {
+    BannerPlugin: {
+        options: webpack.BannerPlugin['options'];
+    };
+    RunScriptWebpackPlugin: {
+        options: ConstructorParameters<typeof RunScriptWebpackPlugin>[number];
+    };
+    ReloadServerPlugin: {
+        done: (...props: unknown[]) => unknown | null;
+        workers: Array<Cluster['Worker']>;
+    };
+    CaseSensitivePathsPlugin: {
+        options: CaseSensitivePathsPlugin.Options;
+        logger: {
+            [K in keyof Console]: Console[K];
+        };
+    };
+    WatchMissingNodeModulesPlugin: {
+        nodeModulesPath: string;
+    };
+};
+
+type SelectedPluginsList<Type extends 'client' | 'server'> = Type extends 'client'
+    ? PluginsListClient
+    : PluginsListServer;
+
+/**
+ *
+ * @param config конфигурация webpack
+ * @param pluginName имя плагина
+ * @returns плагин или плагины, которые подошли под условие из testRule
+ */
+export function findPlugin<Type extends 'client' | 'server'>() {
+    return <PluginName extends keyof SelectedPluginsList<Type>>(
+        config: webpack.Configuration,
+        pluginName: PluginName,
+    ) => {
+        if (!config.plugins || !pluginName) return [];
+
+        const result: Array<SelectedPluginsList<Type>[PluginName]> = [];
+
+        for (const plugin of config.plugins) {
+            if (plugin?.constructor.name === pluginName) {
+                result.push(plugin as any);
+            }
+        }
+
+        return result;
+    };
+}

--- a/packages/arui-scripts/src/configs/webpack.client.dev.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.dev.ts
@@ -1,5 +1,6 @@
 import applyOverrides from './util/apply-overrides';
 import { findLoader } from './util/find-loader';
+import { findPlugin } from './util/find-plugin';
 import { createClientWebpackConfig, createSingleClientWebpackConfig } from './webpack.client';
 
 const config = applyOverrides(
@@ -8,6 +9,7 @@ const config = applyOverrides(
     {
         createSingleClientWebpackConfig: createSingleClientWebpackConfig.bind(null, 'dev'),
         findLoader,
+        findPlugin: findPlugin<'client'>(),
     },
 );
 

--- a/packages/arui-scripts/src/configs/webpack.client.prod.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.prod.ts
@@ -1,5 +1,6 @@
 import applyOverrides from './util/apply-overrides';
 import { findLoader } from './util/find-loader';
+import { findPlugin } from './util/find-plugin';
 import { createClientWebpackConfig, createSingleClientWebpackConfig } from './webpack.client';
 
 const config = applyOverrides(
@@ -8,6 +9,7 @@ const config = applyOverrides(
     {
         createSingleClientWebpackConfig: createSingleClientWebpackConfig.bind(null, 'prod'),
         findLoader,
+        findPlugin: findPlugin<'client'>(),
     },
 );
 

--- a/packages/arui-scripts/src/configs/webpack.server.dev.ts
+++ b/packages/arui-scripts/src/configs/webpack.server.dev.ts
@@ -1,11 +1,12 @@
 import applyOverrides from './util/apply-overrides';
 import { findLoader } from './util/find-loader';
+import { findPlugin } from './util/find-plugin';
 import { createServerConfig } from './webpack.server';
 
 const config = applyOverrides(
     ['webpack', 'webpackServer', 'webpackDev', 'webpackServerDev'],
     createServerConfig('dev'),
-    { findLoader },
+    { findLoader, findPlugin: findPlugin<'server'>() },
 );
 
 export default config;

--- a/packages/arui-scripts/src/configs/webpack.server.prod.ts
+++ b/packages/arui-scripts/src/configs/webpack.server.prod.ts
@@ -1,11 +1,12 @@
 import applyOverrides from './util/apply-overrides';
 import { findLoader } from './util/find-loader';
+import { findPlugin } from './util/find-plugin';
 import { createServerConfig } from './webpack.server';
 
 const config = applyOverrides(
     ['webpack', 'webpackServer', 'webpackProd', 'webpackServerProd'],
     createServerConfig('prod'),
-    { findLoader },
+    { findLoader, findPlugin: findPlugin<'server'>() },
 );
 
 export default config;


### PR DESCRIPTION
Появился findPlugin, который по аналогии с апишкой findLoader позволяет искать и менять конфиги плагинов
Вопросы:
1) Нужно ли такое вообще? (если не брать мастеров-оверрайдеров)
2) в оверрайдах клиента и сервера затипизировал так, чтобы в вызове плагина из webpackClient/Dev появлялись только клиентские плагины, а через webpackServer/Dev только серверные. Смущает немного реализация передачи дженерика внутрь хелпера, сделал через двойной вызов функции, по аналогии с typesafe-actions

Намеренно скипнул оверрайд WMF у клиента, а у сервера - HotModuleReplacementPlugin и NoEmitOnErrorsPlugin