### PR TITLE
fix(dev-server): use ipv4 host for proxy target

### DIFF
--- a/.changeset/fair-starfishes-wait.md
+++ b/.changeset/fair-starfishes-wait.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Исправлен адрес для dev-server на ipv4 для корректной работы с node18

--- a/packages/arui-scripts/src/configs/dev-server.ts
+++ b/packages/arui-scripts/src/configs/dev-server.ts
@@ -21,7 +21,7 @@ const devServerConfig = applyOverrides('devServer', {
     static: [configs.serverOutputPath],
     proxy: Object.assign(configs.proxy || {}, {
         '/**': {
-            target: `http://localhost:${configs.serverPort}`,
+            target: `http://127.0.0.1:${configs.serverPort}`,
             bypass: (req: http.IncomingMessage) => {
                 const assetsRoot = path.normalize(`/${configs.publicPath}`).replace(/\\/g, '/');
 


### PR DESCRIPTION
Фикс для devServer, который приходится сейчас локально переопределять в оверрайдах для корректной работы прокси на проектах, обновившихся до node18.