### PR TITLE
fix(webpack): don't run AruiRuntimeModule on server side

### DIFF
--- a/.changeset/shy-kiwis-crash.md
+++ b/.changeset/shy-kiwis-crash.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Исправлена проблема с запуском AruiRuntimeModule на серверной стороне

--- a/packages/arui-scripts/src/plugins/arui-runtime/arui-runtime-module.ts
+++ b/packages/arui-scripts/src/plugins/arui-runtime/arui-runtime-module.ts
@@ -11,7 +11,7 @@ export class RuntimeModule extends webpack.RuntimeModule {
     // eslint-disable-next-line class-methods-use-this
     generate() {
         return webpack.Template.asString([
-            "if (typeof __webpack_modules__ !== 'undefined') {", // По какой-то причине вебпак пытается выполнить этот код не только в браузере, но и при сборке.
+            "if (typeof __webpack_modules__ !== 'undefined' && typeof document !== 'undefined') {", // По какой-то причине вебпак пытается выполнить этот код не только в браузере, но и при сборке.
             `${FULL_ARUI_RUNTIME_PATH} = { scriptSource: document.currentScript };`,
             '}',
         ]);


### PR DESCRIPTION
Исправлена проблема с запуском рантайм модуля на серверной стороне/рантайме без document. Там он запускаться не должен