### PR TITLE
feat(*): processOptions field for start compiling process

### DIFF
--- a/packages/arui-scripts/src/commands/util/run-compilers.ts
+++ b/packages/arui-scripts/src/commands/util/run-compilers.ts
@@ -15,9 +15,11 @@ export function runCompilers(pathToCompilers: Array<string | string[]>) {
         fs.removeSync(configs.serverOutputPath);
     }
 
+    const { processOptions = [] } = configs;
+
     const compilers = pathToCompilers.map((pathToCompiler) => {
         if (Array.isArray(pathToCompiler)) {
-            const compiler = spawn('node', pathToCompiler, {
+            const compiler = spawn('node', processOptions.concat(pathToCompiler), {
                 stdio: 'inherit',
                 cwd: configs.cwd,
             });
@@ -28,7 +30,7 @@ export function runCompilers(pathToCompilers: Array<string | string[]>) {
             return compiler;
         }
 
-        const compiler = spawn('node', [pathToCompiler], {
+        const compiler = spawn('node', processOptions.concat(pathToCompiler), {
             stdio: 'inherit',
         });
 

--- a/packages/arui-scripts/src/configs/app-configs/get-defaults.ts
+++ b/packages/arui-scripts/src/configs/app-configs/get-defaults.ts
@@ -23,6 +23,7 @@ export function getDefaultAppConfig(): AppConfigs {
         useServerHMR: false,
         presets: configFile?.presets || appPackage?.aruiScripts?.presets || null,
         proxy: appPackage.proxy || null,
+        processOptions: appPackage?.aruiScripts?.processOptions || null,
 
         // paths
         buildPath: '.build',

--- a/packages/arui-scripts/src/configs/app-configs/types.ts
+++ b/packages/arui-scripts/src/configs/app-configs/types.ts
@@ -15,6 +15,7 @@ export type AppConfigs = {
     proxy: null | {
         [url: string]: ProxyConfigArrayItem;
     };
+    processOptions: string[];
 
     // paths
     buildPath: string;


### PR DESCRIPTION
В некоторых случаях при локальной разработке, необходимо передавать дополнительные опции в процесс компиляции. Например в случае если вы используете nodejs версии 17+ и хотите чтобы определение днс адресов обрабатывалось как раньше с приоритетом ipv4, то необходимо будет прокинуть дополнительную опцию '--dns-result-order=ipv4first'