### PR TITLE
fix(alpine-node-nginx): always upgrade all binary dependencies

### DIFF
--- a/packages/alpine-node-nginx/Dockerfile
+++ b/packages/alpine-node-nginx/Dockerfile
@@ -140,12 +140,9 @@ RUN \
 	&& touch /var/log/nginx/access.log /var/log/nginx/error.log \
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
 	&& ln -sf /dev/stderr /var/log/nginx/error.log \
-    # update openssl
-    && apk add --no-cache openssl \
-    # update expat, FIX CVE-2023-52425
-    && apk add --no-cache expat \
-    # update libxml2, FIX CVE-2024-25062
-    && apk add --no-cache libxml2
+    # update all packages to latest
+    && apk update \
+    && apk upgrade --no-cache
 
 COPY nginx.conf /etc/nginx/nginx.conf
 

--- a/packages/alpine-node-nginx/Dockerfile-slim
+++ b/packages/alpine-node-nginx/Dockerfile-slim
@@ -120,7 +120,10 @@ RUN \
 	&& mkdir /var/log/nginx \
 	&& touch /var/log/nginx/access.log /var/log/nginx/error.log \
 	&& ln -sf /dev/stdout /var/log/nginx/access.log \
-	&& ln -sf /dev/stderr /var/log/nginx/error.log
+	&& ln -sf /dev/stderr /var/log/nginx/error.log \
+    # update all packages to latest
+    && apk update \
+    && apk upgrade --no-cache
 
 COPY nginx.conf /etc/nginx/nginx.conf
 


### PR DESCRIPTION
В очередной раз чиним бинарные зависимости. Теперь то уж точно это должно быть последним?
libssl как оказалось идет в комплекте с самим алпайном, поэтому его нужно принудительно обновлять в любом случае