### PR TITLE
feat(tscLoader): mark as deprecated

### DIFF
--- a/.changeset/nasty-humans-retire.md
+++ b/.changeset/nasty-humans-retire.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': major
+---
+
+Флаг useTscLoader помечен как deprecated

--- a/packages/arui-scripts/docs/settings.md
+++ b/packages/arui-scripts/docs/settings.md
@@ -193,7 +193,16 @@ const settings = {
 - `/^thrift-services\/proptypes/`
 
 #### useTscLoader
-Использовать ts-loader вместо babel-loader для обработки ts файлов. У babel-loader есть [ряд ограничений](https://devblogs.microsoft.com/typescript/typescript-and-babel-7/). По умолчанию `false`.
+Использовать ts-loader вместо babel-loader для обработки ts файлов. **Не рекомендуется к использованию**.
+
+babel-loader является предпочтительным инструментом сборки, его стоят заменять только если в вашем проекте используется неподдерживаемый им синтаксис:
+
+- namespaces
+- Кастинг типов через `<Type>value`
+- enum merging
+- legacy import/export (`import = require('module')`, `export = foo`)
+
+Рекомендуется обновить код проекта до поддерживаемого синтаксиса и использовать babel-loader.
 
 #### webpack4Compatibility
 Включить ли режим совместимости с webpack 4. По умолчанию `false`. Подробнее можно почитать в этом [issue](https://github.com/webpack/webpack/issues/14580).

--- a/packages/arui-scripts/src/configs/app-configs/index.ts
+++ b/packages/arui-scripts/src/configs/app-configs/index.ts
@@ -5,6 +5,7 @@ import { updateWithConfigFile } from './update-with-config-file';
 import { updateWithEnv } from './update-with-env';
 import { updateWithPackage } from './update-with-package';
 import { updateWithPresets } from './update-with-presets';
+import { warnAboutDeprecations } from './warn-about-deprecations';
 
 import '../util/register-ts-node';
 
@@ -25,5 +26,7 @@ export const configs: AppContextWithConfigs = {
     ...appConfigs,
     ...appContext,
 };
+
+warnAboutDeprecations(configs);
 
 export default configs;

--- a/packages/arui-scripts/src/configs/app-configs/types.ts
+++ b/packages/arui-scripts/src/configs/app-configs/types.ts
@@ -37,6 +37,9 @@ export type AppConfigs = {
 
     // build tuning
     keepPropTypes: boolean;
+    /**
+     * @deprecated использование ts-loader крайне не рекомендуется - он медленнее и не имеет преимуществ перед babel
+     */
     useTscLoader: boolean;
     webpack4Compatibility: boolean;
     installServerSourceMaps: boolean;

--- a/packages/arui-scripts/src/configs/app-configs/warn-about-deprecations.ts
+++ b/packages/arui-scripts/src/configs/app-configs/warn-about-deprecations.ts
@@ -1,0 +1,12 @@
+import { AppContextWithConfigs } from './types';
+
+export function warnAboutDeprecations(config: AppContextWithConfigs) {
+    if (config.useTscLoader) {
+        // eslint-disable-next-line no-console
+        console.warn(
+            'Использование опции `useTscLoader` не рекомендуется и будет удалено в будущих версиях. ',
+            'Обратитесь к документации https://github.com/core-ds/arui-scripts/blob/master/packages/arui-scripts/docs/settings.md#usetscloader',
+            'для получения дополнительной информации.'
+        );
+    }
+}


### PR DESCRIPTION
ts-loader помечен как deprecated. Когда то давно он был оставлен для совместимости со старыми проектами, сейчас же он создает больше проблем, чем приносит каких либо преимуществ.
babel-loader быстрее, лучше поддерживается и его можно использовать вместе с другими инструментами