### PR TITLE
fix(read-assets-manifest): fix processing assets array

### DIFF
--- a/.changeset/thin-elephants-clap.md
+++ b/.changeset/thin-elephants-clap.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/scripts-server': patch
+---
+
+Исправление обработки массива assets из manifest в функции readAssetsManifest

--- a/packages/arui-scripts-server/src/__tests__/read-assets-manifest.tests.ts
+++ b/packages/arui-scripts-server/src/__tests__/read-assets-manifest.tests.ts
@@ -24,7 +24,7 @@ describe('readAssetsManifest', () => {
                         css: 'vendor.css',
                     },
                     main: {
-                        js: 'main.js',
+                        js: ['main1.js', 'main2.js'],
                         css: 'main.css',
                     },
                 }),
@@ -34,7 +34,7 @@ describe('readAssetsManifest', () => {
         const result = await readAssetsManifest(['vendor', 'main']);
 
         expect(result).toEqual({
-            js: ['vendor.js', 'main.js'],
+            js: ['vendor.js', 'main1.js', 'main2.js'],
             css: ['vendor.css', 'main.css'],
         });
     });

--- a/packages/arui-scripts-server/src/read-assets-manifest.ts
+++ b/packages/arui-scripts-server/src/read-assets-manifest.ts
@@ -23,29 +23,20 @@ export async function getAppManifest() {
 
 export async function readAssetsManifest(bundleNames: string[] = DEFAULT_BUNDLE_NAMES) {
     const manifest = await getAppManifest();
-    const js: string[] = [];
-    const css: string[] = [];
+    let jsArray: string[] = [];
+    let cssArray: string[] = [];
 
     bundleNames.forEach((key) => {
-        if (!manifest[key]) {
-            return;
-        }
+        if (!manifest[key]) return;
 
-        const script = manifest[key].js;
+        const { js, css } = manifest[key];
 
-        if (script) {
-            js.push(script);
-        }
-
-        const style = manifest[key].css;
-
-        if (style) {
-            css.push(style);
-        }
+        if (js) jsArray = jsArray.concat(js);
+        if (css) cssArray = cssArray.concat(css);
     });
 
     return {
-        js,
-        css,
+        js: jsArray,
+        css: cssArray,
     };
 }


### PR DESCRIPTION
readAssetsManifest некорректно обрабатывал ассеты, если их было несколько и лежали в массиве. Если script/style был массивом, то js.push/css.push добавлял их в результат также массивом, не разворачивая. Из за этого вид ответа был не string[], а string[][]