### PR TITLE
fix(*): fix babel preset env config for core-js

### DIFF
--- a/packages/arui-scripts/src/configs/babel-client.ts
+++ b/packages/arui-scripts/src/configs/babel-client.ts
@@ -12,7 +12,7 @@ const babelClientConfig = applyOverrides(['babel', 'babelClient'], {
                 // Allow importing core-js in entrypoint and use browserlist to select polyfills
                 useBuiltIns: 'entry',
                 // Set the corejs version we are using to avoid warnings in console
-                corejs: 3,
+                corejs: '3.32',
                 // Exclude transforms that make all code slower
                 exclude: ['transform-typeof-symbol'],
             },

--- a/packages/arui-scripts/src/configs/babel-dependencies.ts
+++ b/packages/arui-scripts/src/configs/babel-dependencies.ts
@@ -11,7 +11,7 @@ export const babelDependencies = applyOverrides('babelDependencies', {
                 useBuiltIns: 'entry',
                 // Set the corejs version we are using to avoid warnings in console
                 // This will need to change once we upgrade to corejs@3
-                corejs: 3,
+                corejs: "3.32",
                 // Exclude transforms that make all code slower
                 exclude: ['transform-typeof-symbol'],
             },


### PR DESCRIPTION
Нашли проблему, что при импорте core-js в проекте не добавляются полифилы, возможно при текущей настройке матчилась версия core-js 3.0.0, а в аруи скриптах ставится 3.32.0

После данного изменения начали добавляться полифилы