### PR TITLE
fix(arui-scripts): add optional chaining for jest tsconfigs handler

### DIFF
--- a/.changeset/add-tsconfig-optional-chaining.md
+++ b/.changeset/add-tsconfig-optional-chaining.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Исправлено падение при использовании tsconfig, который не содержит поля compilerOptions

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ package-lock.json
 tsconfig.tsbuildinfo
 .turbo
 build
+.DS_Store

--- a/packages/arui-scripts/src/configs/jest/settings.js
+++ b/packages/arui-scripts/src/configs/jest/settings.js
@@ -15,7 +15,7 @@ if (configs.tsconfig) {
     const tsConfigText = fs.readFileSync(configs.tsconfig, 'utf8');
     const tsConfig = parseConfigFileTextToJson(configs.tsconfig, tsConfigText);
 
-    tsConfigPaths = tsConfig.config.compilerOptions.paths || {};
+    tsConfigPaths = tsConfig.config.compilerOptions?.paths || {};
 }
 
 module.exports = {
@@ -31,16 +31,14 @@ module.exports = {
         '^.+\\.tsx?$': configs.jestUseTsJest
             ? require.resolve('ts-jest')
             : require.resolve('./babel-transform'),
-        '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': require.resolve('./file-transform')
+        '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': require.resolve('./file-transform'),
     },
     moduleNameMapper: {
         // replace all css files with simple empty exports
         '\\.css$': require.resolve('./css-mock'),
         ...pathsToModuleNameMapper(tsConfigPaths, { prefix: '<rootDir>/' }),
     },
-    snapshotSerializers: [
-        require.resolve('jest-snapshot-serializer-class-name-to-string')
-    ],
+    snapshotSerializers: [require.resolve('jest-snapshot-serializer-class-name-to-string')],
     globals: {
         'ts-jest': {
             tsconfig: configs.tsconfig,


### PR DESCRIPTION
Происходит падение, если в tsconfig отсутствует поле compilerOptions.
Такое может быть в случае если tsconfig расширяется из другого места.

Ошибка:
```
tsConfigPaths = tsConfig.config.compilerOptions.paths || {};
                                                    ^
TypeError: Cannot read properties of undefined (reading 'paths')
```