### PR TITLE
fix(modules): fixed output.publicPath for compat modules

### DIFF
--- a/.changeset/flat-laws-exercise.md
+++ b/.changeset/flat-laws-exercise.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': major
+---
+
+Исправление настройки output.publicPath в конфиге webpack для compat модулей

--- a/packages/arui-scripts/src/configs/modules.ts
+++ b/packages/arui-scripts/src/configs/modules.ts
@@ -114,7 +114,10 @@ export function patchWebpackConfigForCompat(
     };
     // Название переменной вебпака, которую он будет использовать для загрузки чанков. Важно чтобы для разных модулей они отличались,
     // иначе несколько модулей из одного приложения будут конфликтовать между собой
-    webpackConf.output!.uniqueName = module.name;
+    const uniqueName = module.name;
+
+    // Для того чтобы модули могли подключаться из разных мест, нам необходимо использовать publicPath = auto. Для корректной работы в IE надо подключaть https://github.com/amiller-gh/currentScript-polyfill
+    webpackConf.output = { ...webpackConf.output, publicPath: 'auto', uniqueName };
 
     const cssPrefix = getCssPrefixForModule(module);
 


### PR DESCRIPTION
Для 'compat' модулей, также как и для 'default' модулей настроен output.publicPath = 'auto' в конфиге webpack. Это позволит вебпаку автоматически определять, с какого урла загружать чанки модуля