### PR TITLE
fix(*): fixate swc/core version

### DIFF
--- a/.changeset/thick-planes-sort.md
+++ b/.changeset/thick-planes-sort.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Фиксируем версию swc/core тк на версии 1.10 не работает плагин swc-plugin-coverage-instrument

--- a/packages/arui-scripts/package.json
+++ b/packages/arui-scripts/package.json
@@ -37,7 +37,7 @@
         "@babel/preset-typescript": "^7.23.3",
         "@babel/runtime": "^7.23.8",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
-        "@swc/core": "^1.7.35",
+        "@swc/core": "1.7.35",
         "@swc/jest": "^0.2.36",
         "assets-webpack-plugin": "7.1.1",
         "autoprefixer": "^10.3.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4427,7 +4427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.7.35":
+"@swc/core@npm:1.7.35":
   version: 1.7.35
   resolution: "@swc/core@npm:1.7.35"
   dependencies:
@@ -6477,7 +6477,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.23.3"
     "@babel/runtime": "npm:^7.23.8"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:0.5.11"
-    "@swc/core": "npm:^1.7.35"
+    "@swc/core": "npm:1.7.35"
     "@swc/jest": "npm:^0.2.36"
     "@types/assets-webpack-plugin": "npm:6.1.2"
     "@types/case-sensitive-paths-webpack-plugin": "npm:2.1.6"


### PR DESCRIPTION
Если сейчас обновится до последней версии arui-scripts, где есть swc, то поставится версия `@swc/core: 1.10` а с ней уже не работает `swc-plugin-coverage-instrument`
В консоль сыпит ошибки
`failed to invoke swc-plugin-coverage-instrument as js transform plugin at swc-plugin-coverage-instrument`