### PR TITLE
feat(*): update nodejs to lts 22.14.0

### DIFF
--- a/.github/workflows/alpine-node.yml
+++ b/.github/workflows/alpine-node.yml
@@ -16,12 +16,12 @@ jobs:
           { node: '16.20.2', alpine: '3.18', image: node, dockerfile: Dockerfile, tag: '16.20.2' },
           { node: '18.20.6', alpine: '3.20', image: node, dockerfile: Dockerfile, tag: '18.20.6' },
           { node: '20.18.2', alpine: '3.20', image: node, dockerfile: Dockerfile, tag: '20.18.2' },
-          { node: '22.13.1', alpine: '3.20', image: node, dockerfile: Dockerfile, tag: '22.13.1' },
+          { node: '22.14.0', alpine: '3.20', image: node, dockerfile: Dockerfile, tag: '22.14.0' },
 
           { node: '16.20.2', alpine: '3.18', image: node, dockerfile: Dockerfile-slim, tag: '16.20.2-slim' },
           { node: '18.20.6', alpine: '3.20', image: node, dockerfile: Dockerfile-slim, tag: '18.20.6-slim' },
           { node: '20.18.2', alpine: '3.20', image: node, dockerfile: Dockerfile-slim, tag: '20.18.2-slim' },
-          { node: '22.13.1', alpine: '3.20', image: node, dockerfile: Dockerfile-slim, tag: '22.13.1-slim' },
+          { node: '22.14.0', alpine: '3.20', image: node, dockerfile: Dockerfile-slim, tag: '22.14.0-slim' },
         ]
     runs-on: ubuntu-latest
     steps:

--- a/packages/alpine-node-nginx/README.md
+++ b/packages/alpine-node-nginx/README.md
@@ -16,7 +16,7 @@ alpine-node-nginx
 - 16.20.2, 16.20.2-slim (EOL - этот образ более обновляться не будет)
 - 18.20.6, 18.20.6-slim
 - 20.18.2, 20.18.2-slim
-- 22.13.1, 22.13.1-slim
+- 22.14.0, 22.14.0-slim
 - nginx-1.27.1-slim
 
 Наиболее актуальный список тегов можно найти на [dockerhub](https://hub.docker.com/r/alfabankui/arui-scripts/tags).


### PR DESCRIPTION
Обновление до последней LTS версии 22.14.0
в 22.13.1 в appsec есть уязвимости:

```
Уязвимость найдена в модуле libcrypto3@3.3.2-r1.

CVE: CVE-2024-12797.
```
```
Уязвимость найдена в модуле libssl3@3.3.2-r1.

CVE: CVE-2024-12797.
```