### PR TITLE
feat(alpine-node): update alpine to 3.20.6

### DIFF
--- a/.github/workflows/alpine-node.yml
+++ b/.github/workflows/alpine-node.yml
@@ -16,12 +16,12 @@ jobs:
           { node: '16.20.2', alpine: '3.18', image: node, dockerfile: Dockerfile, tag: '16.20.2' },
           { node: '18.20.6', alpine: '3.20', image: node, dockerfile: Dockerfile, tag: '18.20.6' },
           { node: '20.18.3', alpine: '3.20', image: node, dockerfile: Dockerfile, tag: '20.18.3' },
-          { node: '22.14.0', alpine: '3.20', image: node, dockerfile: Dockerfile, tag: '22.14.0' },
+          { node: '22.14.0', alpine: '3.20.6', image: node, dockerfile: Dockerfile, tag: '22.14.0' },
 
           { node: '16.20.2', alpine: '3.18', image: node, dockerfile: Dockerfile-slim, tag: '16.20.2-slim' },
           { node: '18.20.6', alpine: '3.20', image: node, dockerfile: Dockerfile-slim, tag: '18.20.6-slim' },
           { node: '20.18.3', alpine: '3.20', image: node, dockerfile: Dockerfile-slim, tag: '20.18.3-slim' },
-          { node: '22.14.0', alpine: '3.20', image: node, dockerfile: Dockerfile-slim, tag: '22.14.0-slim' },
+          { node: '22.14.0', alpine: '3.20.6', image: node, dockerfile: Dockerfile-slim, tag: '22.14.0-slim' },
         ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/alpine-node.yml
+++ b/.github/workflows/alpine-node.yml
@@ -14,14 +14,14 @@ jobs:
       matrix:
         versions: [
           { node: '16.20.2', alpine: '3.18', image: node, dockerfile: Dockerfile, tag: '16.20.2' },
-          { node: '18.20.6', alpine: '3.20', image: node, dockerfile: Dockerfile, tag: '18.20.6' },
-          { node: '20.18.3', alpine: '3.20', image: node, dockerfile: Dockerfile, tag: '20.18.3' },
-          { node: '22.14.0', alpine: '3.20.6', image: node, dockerfile: Dockerfile, tag: '22.14.0' },
+          { node: '18.20.6', alpine: '3.21', image: node, dockerfile: Dockerfile, tag: '18.20.6' },
+          { node: '20.18.3', alpine: '3.21', image: node, dockerfile: Dockerfile, tag: '20.18.3' },
+          { node: '22.14.0', alpine: '3.21', image: node, dockerfile: Dockerfile, tag: '22.14.0' },
 
           { node: '16.20.2', alpine: '3.18', image: node, dockerfile: Dockerfile-slim, tag: '16.20.2-slim' },
-          { node: '18.20.6', alpine: '3.20', image: node, dockerfile: Dockerfile-slim, tag: '18.20.6-slim' },
-          { node: '20.18.3', alpine: '3.20', image: node, dockerfile: Dockerfile-slim, tag: '20.18.3-slim' },
-          { node: '22.14.0', alpine: '3.20.6', image: node, dockerfile: Dockerfile-slim, tag: '22.14.0-slim' },
+          { node: '18.20.6', alpine: '3.21', image: node, dockerfile: Dockerfile-slim, tag: '18.20.6-slim' },
+          { node: '20.18.3', alpine: '3.21', image: node, dockerfile: Dockerfile-slim, tag: '20.18.3-slim' },
+          { node: '22.14.0', alpine: '3.21', image: node, dockerfile: Dockerfile-slim, tag: '22.14.0-slim' },
         ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
В текущих образах используется alpine 3.20.5 в которых есть уязвимости критичного уровня, на которые ругается апсек
https://hub.docker.com/layers/library/alpine/3.20.5/images/sha256-cbbabaca3bd3b2617ffff036d987a82bcfe923fd4bf985f338c12e74af1bd081

В частности CVE 2024-12797, который был исправлен в версии alpine 3.20.6
https://hub.docker.com/layers/library/alpine/3.20.6/images/sha256-367c8801047a3ab67a580e2ab142a2018d00e43b3573d81519a8f79576fbdbba