### PR TITLE
fix(configs/webpack): add cjs extension to getExternalCodeLoader

### DIFF
--- a/.changeset/empty-hornets-burn.md
+++ b/.changeset/empty-hornets-burn.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Добавлено расширение cjs в getExternalCodeLoader, так как некоторые внешние библиотеки экспортируют .cjs, например redux ^5.0.0

--- a/packages/arui-scripts/src/configs/webpack.client.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.ts
@@ -558,7 +558,7 @@ function getTsLoaderIfEnabled(mode: 'dev' | 'prod'): RuleSetRule | false {
 
 function getExternalCodeLoader(mode: 'dev' | 'prod'): RuleSetRule {
     const baseLoaderConfig = {
-        test: /\.(js|mjs)$/,
+        test: /\.(js|mjs|cjs)$/,
         exclude: /@babel(?:\/|\\{1,2})runtime/,
         resolve: {
             fullySpecified: false,

--- a/packages/arui-scripts/src/configs/webpack.server.ts
+++ b/packages/arui-scripts/src/configs/webpack.server.ts
@@ -265,7 +265,7 @@ function getTsLoaderIfEnabled(mode: 'dev' | 'prod'): RuleSetRule | false {
 
 function getExternalCodeLoader(mode: 'dev' | 'prod'): RuleSetRule {
     const baseLoaderConfig = {
-        test: /\.(js|mjs)$/,
+        test: /\.(js|mjs|cjs)$/,
         exclude: /@babel(?:\/|\\{1,2})runtime/,
         resolve: {
             fullySpecified: false,


### PR DESCRIPTION
При попытке обновиться до RTK 2.0 столкнулся с ошибкой `(0 , redux_1.createStore) is not a function`. После небольшого исследования выяснил, что redux выпадал в assets, сборщик обрабатывал его как статику, а require('./node_modules/redux/dist/cjs/redux.cjs') при сборке возвращал строку 'assets/static/media/redux.a7cedf98.cjs' вместо модуля
![image](https://github.com/user-attachments/assets/1329f438-d9cd-4ee5-9cba-d4f9a848f49b)

Связано с тем, что с версии 5 в redux появился exports в package.json, и по умолчанию он ведет к `.cjs` файлу
![image](https://github.com/user-attachments/assets/e1525567-c7a6-47e4-a69e-5eeaba83fb4b)
![image](https://github.com/user-attachments/assets/e478991c-d193-4221-a466-6957d254c991)

Выяснил что в arui-script конфигах webpack есть функция `getExternalCodeLoader`, отвечающая за обработку node_modules. Добавление в неё `cjs` расширение исправляет проблему

![image](https://github.com/user-attachments/assets/50ba69c2-d396-4f7b-a09f-f2ff665d9e9b)
