### PR TITLE
Поддержка свойства shareScope для модулей

### DIFF
--- a/.changeset/chatty-squids-kiss.md
+++ b/.changeset/chatty-squids-kiss.md
@@ -1,0 +1,6 @@
+---
+'@alfalab/scripts-modules': patch
+'arui-scripts': patch
+---
+
+Добавлена поддержка свойства shareScope для использования в модулях

--- a/packages/arui-scripts-modules/README.md
+++ b/packages/arui-scripts-modules/README.md
@@ -45,6 +45,7 @@ const loader = createModuleLoader({
     // опциональные параметры
     resourceCache: 'single-item', // политика кеширования ресурсов модуля. Если 'none' - ресурсы модуля будут удалены из кеша после его удаления со страницы. Если 'single-item' - в кеше будет храниться значения для текущего значения loaderParams.
     resourcesTargetNode: document.head, // DOM-нода, в которую будут монтироваться ресурсы модуля (css и js)
+    shareScope // параметр, который необходимо указать если shareScope модуля отличается от default
     onBeforeResourcesMount: (moduleId, resources) => {}, // коллбек, который будет вызван перед монтированием ресурсов
     onBeforeModuleMount: (moduleId, resources) => {}, // коллбек, который будет вызван перед монтированием модуля
     onAfterModuleMount: (moduleId, resources, module) => {}, // коллбек, который будет вызван после монтирования модуля

--- a/packages/arui-scripts-modules/global-definitions.d.ts
+++ b/packages/arui-scripts-modules/global-definitions.d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention,no-underscore-dangle */
 declare const __webpack_share_scopes__: {
     default: unknown;
+    [customScope: string]: unknown;
 };
 /* eslint-enable @typescript-eslint/naming-convention,no-underscore-dangle */

--- a/packages/arui-scripts-modules/src/module-loader/__tests__/create-module-loader.tests.ts
+++ b/packages/arui-scripts-modules/src/module-loader/__tests__/create-module-loader.tests.ts
@@ -157,6 +157,7 @@ describe('createModuleLoader', () => {
             moduleId: 'test',
             hostAppId: 'test',
             getModuleResources,
+            sharedScope: 'exampleScope',
         });
 
         getModuleResources.mockResolvedValue({
@@ -171,7 +172,7 @@ describe('createModuleLoader', () => {
 
         await loader({ getResourcesParams: undefined });
 
-        expect(getModule).toHaveBeenCalledWith('AppName', 'test');
+        expect(getModule).toHaveBeenCalledWith('AppName', 'test', 'exampleScope');
     });
 
     it('should call getCompatModule with correct params if mountMode is compat', async () => {
@@ -215,7 +216,7 @@ describe('createModuleLoader', () => {
         (getModule as jest.Mock).mockResolvedValueOnce(undefined);
 
         await expect(loader({ getResourcesParams: undefined })).rejects.toThrow(
-            'Module test is not available'
+            'Module test is not available',
         );
     });
 
@@ -273,7 +274,10 @@ describe('createModuleLoader', () => {
 
         unmount();
 
-        expect(domUtils.removeModuleResources).toHaveBeenCalledWith({ moduleId: 'unique-id', targetNodes: [] });
+        expect(domUtils.removeModuleResources).toHaveBeenCalledWith({
+            moduleId: 'unique-id',
+            targetNodes: [],
+        });
         expect(cleanGlobal.cleanGlobal).toHaveBeenCalledWith('unique-id');
     });
 
@@ -290,9 +294,9 @@ describe('createModuleLoader', () => {
 
             abortController.abort();
 
-            await expect(loader({ getResourcesParams: undefined, abortSignal: abortController.signal })).rejects.toThrow(
-                'Module test loading was aborted'
-            );
+            await expect(
+                loader({ getResourcesParams: undefined, abortSignal: abortController.signal }),
+            ).rejects.toThrow('Module test loading was aborted');
 
             expect(getModuleResources).not.toHaveBeenCalled();
         });
@@ -356,7 +360,10 @@ describe('createModuleLoader', () => {
 
             abortController.abort();
 
-            expect(domUtils.removeModuleResources).toHaveBeenCalledWith({ moduleId: 'another-id', targetNodes: [] });
+            expect(domUtils.removeModuleResources).toHaveBeenCalledWith({
+                moduleId: 'another-id',
+                targetNodes: [],
+            });
             expect(cleanGlobal.cleanGlobal).toHaveBeenCalledWith('another-id');
         });
     });
@@ -375,8 +382,10 @@ describe('createModuleLoader', () => {
                 resourcesCache: 'single-item',
             });
 
-            await expect(loader({ getResourcesParams: undefined, useShadowDom: true })).rejects.toThrow(
-                'Загрузка модулей в shadow DOM при использовании `resourceCache: single-item` не поддерживается.'
+            await expect(
+                loader({ getResourcesParams: undefined, useShadowDom: true }),
+            ).rejects.toThrow(
+                'Загрузка модулей в shadow DOM при использовании `resourceCache: single-item` не поддерживается.',
             );
         });
 

--- a/packages/arui-scripts-modules/src/module-loader/__tests__/create-module-loader.tests.ts
+++ b/packages/arui-scripts-modules/src/module-loader/__tests__/create-module-loader.tests.ts
@@ -157,7 +157,7 @@ describe('createModuleLoader', () => {
             moduleId: 'test',
             hostAppId: 'test',
             getModuleResources,
-            sharedScope: 'exampleScope',
+            shareScope: 'exampleScope',
         });
 
         getModuleResources.mockResolvedValue({

--- a/packages/arui-scripts-modules/src/module-loader/create-module-loader.ts
+++ b/packages/arui-scripts-modules/src/module-loader/create-module-loader.ts
@@ -50,7 +50,7 @@ export type CreateModuleLoaderParams<
     onAfterModuleUnmount?: ModuleLoaderHookWithModule<ModuleExportType, ModuleState>;
     /** политика кеширования ресурсов модуля. Если 'none' - ресурсы модуля будут удалены из кеша после его удаления со страницы. Если 'single-item' - в кеше будет храниться значения для текущего значения loaderParams. */
     resourcesCache?: 'none' | 'single-item';
-    /** sharedScope модуля, если отличается от default*/
+    /** sharedScope модуля, если отличается от default */
     sharedScope?: string;
 };
 

--- a/packages/arui-scripts-modules/src/module-loader/create-module-loader.ts
+++ b/packages/arui-scripts-modules/src/module-loader/create-module-loader.ts
@@ -50,8 +50,8 @@ export type CreateModuleLoaderParams<
     onAfterModuleUnmount?: ModuleLoaderHookWithModule<ModuleExportType, ModuleState>;
     /** политика кеширования ресурсов модуля. Если 'none' - ресурсы модуля будут удалены из кеша после его удаления со страницы. Если 'single-item' - в кеше будет храниться значения для текущего значения loaderParams. */
     resourcesCache?: 'none' | 'single-item';
-    /** sharedScope модуля, если отличается от default */
-    sharedScope?: string;
+    /** shareScope модуля, если отличается от default */
+    shareScope?: string;
 };
 
 const consumerCounter = getConsumerCounter();
@@ -71,7 +71,7 @@ export function createModuleLoader<
     onAfterModuleMount,
     onBeforeModuleUnmount,
     onAfterModuleUnmount,
-    sharedScope,
+    shareScope,
 }: CreateModuleLoaderParams<ModuleExportType, GetResourcesParams, ModuleState>): Loader<
     GetResourcesParams,
     ModuleExportType
@@ -188,7 +188,7 @@ export function createModuleLoader<
         // В зависимости от типа модуля, получаем его контент необходимым способом
         const loadedModule =
             moduleResources.mountMode === 'default'
-                ? await getModule<ModuleExportType>(moduleResources.appName, moduleId, sharedScope)
+                ? await getModule<ModuleExportType>(moduleResources.appName, moduleId, shareScope)
                 : getCompatModule<ModuleExportType>(moduleId);
 
         if (!loadedModule) {

--- a/packages/arui-scripts-modules/src/module-loader/utils/get-module.ts
+++ b/packages/arui-scripts-modules/src/module-loader/utils/get-module.ts
@@ -4,15 +4,20 @@ import { ModuleFederationContainer } from '../types';
  * Метод для получения контента уже загруженного модуля
  * @param containerId
  * @param moduleId
+ * @param [shareScope='default']
  */
-export async function getModule<ModuleType>(containerId: string, moduleId: string) {
+export async function getModule<ModuleType>(
+    containerId: string,
+    moduleId: string,
+    shareScope: string = 'default',
+) {
     // module federation работает таким образом:
     // 1. Инициализация shared скоупа. Фактически загружает в него все известные приложению на данный момент модули (и из себя, и из других remote, если есть)
     // 2. вебпак пишет нужный "контейнер" в window. Под контейнером понимается совокупность модулей от какого то приложения
     // 3. мы инициализируем контейнер. Он может записать шареные модули в общий скоуп
     // 4. мы получаем из контейнера тот модуль, который нас интересовал. Собственно в нашем случае в контейнере будет только один модуль
     // 5. "запускаем" модуль. Он вернет нам то, что заэкспорчено из файла, который предоставляет module federation
-    await __webpack_init_sharing__('default');
+    await __webpack_init_sharing__(shareScope);
     const container = (window as unknown as Record<string, ModuleFederationContainer>)[containerId];
 
     if (!container || !container.init) {
@@ -23,7 +28,7 @@ export async function getModule<ModuleType>(containerId: string, moduleId: strin
 
     // webpack любит двойные подчеркивания для внутренних функций
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    await container.init(__webpack_share_scopes__.default);
+    await container.init(__webpack_share_scopes__[shareScope]);
     const factory = await container.get<ModuleType>(moduleId);
 
     if (!factory) {

--- a/packages/arui-scripts-modules/src/module-loader/utils/get-module.ts
+++ b/packages/arui-scripts-modules/src/module-loader/utils/get-module.ts
@@ -9,7 +9,7 @@ import { ModuleFederationContainer } from '../types';
 export async function getModule<ModuleType>(
     containerId: string,
     moduleId: string,
-    shareScope: string = 'default',
+    shareScope = 'default',
 ) {
     // module federation работает таким образом:
     // 1. Инициализация shared скоупа. Фактически загружает в него все известные приложению на данный момент модули (и из себя, и из других remote, если есть)

--- a/packages/arui-scripts/docs/modules.md
+++ b/packages/arui-scripts/docs/modules.md
@@ -719,6 +719,7 @@ type Modules = {
         [moduleId: string]: string; // moduleId - id модуля, value - путь до точки входа модуля
     };
     shared?: (string | SharedObject)[] | SharedObject; // конфигурация shared параметра для ModuleFederationPlugin
+    shareScope?: string // скоуп который будет присваиваться модулям в shared если иное имя не будет задано в sharedConfig. Значение по умолчанию - 'default'
 };
 
 type SharedObject = {

--- a/packages/arui-scripts/src/configs/app-configs/types.ts
+++ b/packages/arui-scripts/src/configs/app-configs/types.ts
@@ -94,6 +94,7 @@ export type AppConfigs = {
         exposes?: Record<string, string>;
         options?: ModuleConfigBase;
     } | null;
+    shareScope?: string;
 };
 
 export type ModuleConfigBase = {

--- a/packages/arui-scripts/src/configs/app-configs/types.ts
+++ b/packages/arui-scripts/src/configs/app-configs/types.ts
@@ -93,8 +93,8 @@ export type AppConfigs = {
         shared: any; // webpack don't expose this type
         exposes?: Record<string, string>;
         options?: ModuleConfigBase;
+        shareScope?: string;
     } | null;
-    shareScope?: string;
 };
 
 export type ModuleConfigBase = {

--- a/packages/arui-scripts/src/configs/modules.ts
+++ b/packages/arui-scripts/src/configs/modules.ts
@@ -52,6 +52,7 @@ export function patchMainWebpackConfigForModules(webpackConf: rspack.Configurati
             filename: configs.modules.exposes ? MODULES_ENTRY_NAME : undefined,
             shared: configs.modules.shared,
             exposes: configs.modules.exposes,
+            shareScope: configs.shareScope
         }),
         new TurnOffSplitRemoteEntry(configs.modules.name || configs.normalizedName),
     );

--- a/packages/arui-scripts/src/configs/modules.ts
+++ b/packages/arui-scripts/src/configs/modules.ts
@@ -52,7 +52,7 @@ export function patchMainWebpackConfigForModules(webpackConf: rspack.Configurati
             filename: configs.modules.exposes ? MODULES_ENTRY_NAME : undefined,
             shared: configs.modules.shared,
             exposes: configs.modules.exposes,
-            shareScope: configs.shareScope
+            shareScope: configs.modules.shareScope
         }),
         new TurnOffSplitRemoteEntry(configs.modules.name || configs.normalizedName),
     );


### PR DESCRIPTION
Некоторые микрофронты нашего проекта будут встраиваться в проекты других команд, некоторые из них находятся на очень старых версиях библиотек. Для корректной отработки таких ситуаций необходима поддержка и корректная обработка свойства shareScope - при загрузке модуля, а так же инициализации wmf плагина