### PR TITLE
feat(*): add app-html to exemptions | JSCOM-45

### DIFF
--- a/.changeset/happy-turtles-applaud.md
+++ b/.changeset/happy-turtles-applaud.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': minor
+---
+
+Добавление пакета @alfa-bank/app-html в serverExternalsExemptions

--- a/packages/arui-scripts/src/configs/server-externals-exemptions.ts
+++ b/packages/arui-scripts/src/configs/server-externals-exemptions.ts
@@ -5,6 +5,7 @@ export const serverExternalsExemptions = applyOverrides('serverExternalsExemptio
     /^arui-private/,
     /^alfaform-core-ui/,
     /^@alfa-bank\/newclick-composite-components/,
+    /^@alfa-bank\/app-html/,
     /^#/,
     /^@alfalab\/icons/,
     /^@alfalab\/core-components/,


### PR DESCRIPTION
Новый пакет выдает ворнинги на иконки внутри node_modules
```
WARNING!
    Trying to require /Users/admin/Documents/Repos/corp-shared-ui/node_modules/@alfa-bank/app-html/dist/icons/apple-touch-icon-120x120.png in node.js.
    Non-js files is ignored when required in node_modules
```