### PR TITLE
fix(client-only): dev server history fallback for client only mode

### DIFF
--- a/.changeset/sweet-knives-punch.md
+++ b/.changeset/sweet-knives-punch.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Включен devserver.historyApiFallback для clientOnly режима. Теперь в дев режиме в clientOnly запросы на неизвестные адреса будут открывать index.html

--- a/packages/arui-scripts/src/configs/dev-server.ts
+++ b/packages/arui-scripts/src/configs/dev-server.ts
@@ -49,6 +49,7 @@ const serverProxyConfig = {
 export const devServerConfig = applyOverrides('devServer', {
     port: configs.clientServerPort,
     liveReload: false,
+    historyApiFallback: configs.clientOnly,
     client: {
         overlay: {
             errors: true,


### PR DESCRIPTION
Исправлена работа clientOnly в дев режиме - теперь запросы на неизвестные адреса будут корректно фолбечится на index.html. В скомпиленном виде nginx и так корректно это делал, в дев режиме же мы получали 404