### PR TITLE
fix(docker-build): patched yarn cache cleaning with 'docker-build:com…

### DIFF
--- a/.changeset/lazy-chairs-return.md
+++ b/.changeset/lazy-chairs-return.md
@@ -1,0 +1,9 @@
+---
+'arui-scripts': patch
+---
+
+Изменена команда для очистки кэша yarn при сборке docker-образа через `docker-build:compiled`
+
+Теперь команда выглядит так: `yarn cache clean --all`
+
+Благодаря этому изменению, размер образов, собираемых через `docker-build:compiled`, станет меньше

--- a/packages/arui-scripts/src/templates/dockerfile-compiled.template.ts
+++ b/packages/arui-scripts/src/templates/dockerfile-compiled.template.ts
@@ -35,7 +35,7 @@ ${filesRequiredToInstallDependencies
     .join('\n')}
 
 RUN ${installProductionCommand}  && \\
-    ${yarnVersion === 'unavailable' ? 'npm cache clean --force' : 'yarn cache clean'}
+    ${yarnVersion === 'unavailable' ? 'npm cache clean --force' : 'yarn cache clean --all'}
 
 ADD --chown=nginx:nginx . /src
 


### PR DESCRIPTION
Полное описание проблемы можно посмотреть в #366 

Увеличенный размер docker-образа при сборке через docker-build:compiled был вызван наличием кэша yarn, собранного при сборке зависимостей. Команда `yarn cache clean` чистит только **локальный кэш**, но, судя по всему, при сборке также создавался и глобальный кэш, который можно почистить через добавление флага `--all`