### PR TITLE
add settings ngnix conf for no cache remoteEntry.js

### DIFF
--- a/.changeset/dirty-eels-move.md
+++ b/.changeset/dirty-eels-move.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': minor
+---
+
+добавлена настройка отключения кеширования remoteEntry.js в шаблон ngnix.conf

--- a/packages/arui-scripts/src/templates/nginx.conf.template.ts
+++ b/packages/arui-scripts/src/templates/nginx.conf.template.ts
@@ -30,6 +30,16 @@ server {
         root ${configs.nginxRootPath}/${configs.buildPath};
     }
 
+    location = /${configs.publicPath}remoteEntry.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+        root ${configs.nginxRootPath}/${configs.buildPath};
+        types {
+            text/javascript  js;
+        }
+    }
+
     location ~ /${configs.publicPath}.*\\.js$ {
         expires max;
         add_header Cache-Control public;


### PR DESCRIPTION
Отключение кэширования для remoteEntry.js, что получать всегда актуальную версию файла