### PR TITLE
fix(exemptions): fix package name after its renaming

### DIFF
--- a/.changeset/moody-jars-protect.md
+++ b/.changeset/moody-jars-protect.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Исправляем название пакета на common-app-html в exemptions

--- a/packages/arui-scripts/src/configs/server-externals-exemptions.ts
+++ b/packages/arui-scripts/src/configs/server-externals-exemptions.ts
@@ -5,7 +5,7 @@ export const serverExternalsExemptions = applyOverrides('serverExternalsExemptio
     /^arui-private/,
     /^alfaform-core-ui/,
     /^@alfa-bank\/newclick-composite-components/,
-    /^@alfa-bank\/app-html/,
+    /^@alfa-bank\/common-app-html/,
     /^#/,
     /^@alfalab\/icons/,
     /^@alfalab\/core-components/,


### PR DESCRIPTION
После переименования пакета, забыли переименовать его в exemptions. Снова пошли warnings
Исправляю