### PR TITLE
fix(*): fix Windows path imports

### DIFF
--- a/.changeset/wild-nails-trade.md
+++ b/.changeset/wild-nails-trade.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Исправлен запуск Jest на Windows из-за абсолютных путей в import

--- a/packages/arui-scripts/src/commands/test/get-config.ts
+++ b/packages/arui-scripts/src/commands/test/get-config.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
 import { replaceRootDirInPath } from 'jest-config';
 import Resolver from 'jest-resolve';
@@ -29,7 +30,7 @@ async function getAppJestConfig() {
     const jestConfigPath = path.resolve(process.cwd(), 'jest.config.js');
 
     if (fs.existsSync(jestConfigPath)) {
-        return (await import(jestConfigPath)).default;
+        return (await import(pathToFileURL(jestConfigPath).href)).default;
     }
 
     if (configs.appPackage.jest) {
@@ -60,7 +61,8 @@ async function getPresetConfig(presetPath?: string) {
         throw new Error(`Cannot find module '${normalizedPresetPath}'`);
     }
 
-    const { preset: subPreset, ...preset } = (await import(presetModule)).default;
+    const { preset: subPreset, ...preset } = (await import(pathToFileURL(presetModule).href))
+        .default;
 
     if (subPreset) {
         console.warn(`Jest can't handle preset chaining. Preset "${subPreset}" will be ignored.`);


### PR DESCRIPTION
Фикс ошибки запуска Jest на Windows после перехода на 21 версию arui-scripts
`Error running Jest: Error: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'`