### PR TITLE
chore(ci): remove example and example modules from changeset releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,14 +1,11 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": [
-      "@changesets/changelog-github",
-      { "repo": "core-ds/arui-scripts" }
-  ],
-  "commit": false,
-  "fixed": [],
-  "linked": [],
-  "access": "public",
-  "baseBranch": "master",
-  "updateInternalDependencies": "patch",
-  "ignore": []
+    "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+    "changelog": ["@changesets/changelog-github", { "repo": "core-ds/arui-scripts" }],
+    "commit": false,
+    "fixed": [],
+    "linked": [],
+    "access": "public",
+    "baseBranch": "master",
+    "updateInternalDependencies": "patch",
+    "ignore": ["example", "example-modules"]
 }

--- a/packages/arui-scripts/CHANGELOG.md
+++ b/packages/arui-scripts/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [15.3.0](https://github.com/core-ds/arui-scripts/compare/v15.2.0...v15.3.0) (2023-06-30)
+# arui-scripts
 
 ## 21.0.4
 


### PR DESCRIPTION
Убираем лишний шум со страницы релизов