### PR TITLE
disabled autoprefixer in server postcss config

### DIFF
--- a/.changeset/silent-autoprefixer-server.md
+++ b/.changeset/silent-autoprefixer-server.md
@@ -1,0 +1,5 @@
+---
+"arui-scripts": patch
+---
+
+Отключен autoprefixer в cерверной конфигурации postcss, чтобы CSS modules в server сборке не генерировали предупреждения при таргете `current node`.

--- a/packages/arui-scripts/src/configs/postcss.config.ts
+++ b/packages/arui-scripts/src/configs/postcss.config.ts
@@ -7,10 +7,11 @@ import { postCssGlobalVariables } from '../plugins/postcss-global-variables/post
 import { configs as config } from './app-configs';
 
 type PostCssPluginName = string | PluginCreator<unknown>;
-type PostcssPlugin =
+export type PostcssPlugin =
     | string
     | [string, unknown]
-    | { name: string; plugin: PluginCreator<unknown>; options?: unknown };
+    | { name: string; plugin: PluginCreator<unknown>; options?: unknown }
+    | { postcssPlugin: string };
 
 /**
  * Функция для создания конфигурационного файла postcss

--- a/packages/arui-scripts/src/configs/postcss.ts
+++ b/packages/arui-scripts/src/configs/postcss.ts
@@ -1,11 +1,42 @@
 import { applyOverrides } from './util/apply-overrides';
-import { createPostcssConfig, postcssPlugins, postcssPluginsOptions } from './postcss.config';
+import {
+    createPostcssConfig,
+    type PostcssPlugin,
+    postcssPlugins,
+    postcssPluginsOptions,
+} from './postcss.config';
 
-export const postcssConfig = applyOverrides(
+const postcssConfigWithOverrides = applyOverrides(
     'postcss',
     createPostcssConfig(postcssPlugins, postcssPluginsOptions),
     // тк дается возможность переопределять options для плагинов импортируемых напрямую
     // инициализировать их нужно после оверайдов
-).map((plugin) =>
-    typeof plugin === 'string' || Array.isArray(plugin) ? plugin : plugin.plugin(plugin.options),
+);
+
+const isResolvedPostcssPlugin = (plugin: PostcssPlugin): plugin is { postcssPlugin: string } =>
+    typeof plugin === 'object' && !Array.isArray(plugin) && 'postcssPlugin' in plugin;
+
+const resolvePostcssConfig = (plugins: PostcssPlugin[]) =>
+    plugins.map((plugin) =>
+        typeof plugin === 'string' || Array.isArray(plugin) || isResolvedPostcssPlugin(plugin)
+            ? plugin
+            : plugin.plugin(plugin.options),
+    );
+
+const isAutoprefixerPlugin = (plugin: PostcssPlugin) => {
+    if (plugin === 'autoprefixer') {
+        return true;
+    }
+
+    if (Array.isArray(plugin)) {
+        return plugin[0] === 'autoprefixer';
+    }
+
+    return isResolvedPostcssPlugin(plugin) && plugin.postcssPlugin === 'autoprefixer';
+};
+
+export const postcssConfig = resolvePostcssConfig(postcssConfigWithOverrides);
+
+export const serverPostcssConfig = resolvePostcssConfig(
+    postcssConfigWithOverrides.filter((plugin) => !isAutoprefixerPlugin(plugin)),
 );

--- a/packages/arui-scripts/src/configs/webpack.server.ts
+++ b/packages/arui-scripts/src/configs/webpack.server.ts
@@ -20,7 +20,7 @@ import { getEntry } from './util/get-entry';
 import { configs } from './app-configs';
 import { babelDependencies } from './babel-dependencies';
 import { config as babelConf } from './babel-server';
-import { postcssConfig as postcssConf } from './postcss';
+import { serverPostcssConfig as postcssConf } from './postcss';
 import { serverExternalsExemptions } from './server-externals-exemptions';
 import { swcServerConfig } from './swc';
 import { getLocalIdent } from '../commands/util/get-local-ident';


### PR DESCRIPTION
**Проблема:**
серверная сборка arui-scripts использует тот же postсss конфиг, что и клиентская, включая autoprefixer
 
**Мотивация:**
Исправляет варнинги autoprefixer при сборке CSS modules для server bundle с таргетом current node
<img width="1271" height="390" alt="Снимок экрана 2026-05-05 в 18 23 25" src="https://github.com/user-attachments/assets/d412555f-9948-4fd1-9f34-3fa935b4daf9" />

**Что сделано:**
убрали autoprefixer из postcss конфига серверной сборки arui-scripts
клиентская сборка продолжает использовать autoprefixer без изменений