### PR TITLE
fix: add CFLAGS to ignore GCC 15 warning when building nginx

### DIFF
--- a/.changeset/moody-pigs-push.md
+++ b/.changeset/moody-pigs-push.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts-docker': patch
+---
+
+исправление сборки docker образа с alpine v3.23: добавлен CFLAGS для игнорирования предупреждения GCC 15 при сборке nginx

--- a/packages/alpine-node-nginx/Dockerfile-nginx-slim
+++ b/packages/alpine-node-nginx/Dockerfile-nginx-slim
@@ -76,12 +76,13 @@ RUN \
     && tar -zxC /usr/src -f nginx.tar.gz
 
 RUN \
-    cd /usr/src/nginx-$NGINX_VERSION \
-    && ./configure $NGINX_CONFIG \
-    && make -j$(getconf _NPROCESSORS_ONLN) \
-    && mv objs/nginx objs/nginx-debug \
-    && ./configure $NGINX_CONFIG \
-    && make -j$(getconf _NPROCESSORS_ONLN)
+	cd /usr/src/nginx-$NGINX_VERSION \
+	&& export CFLAGS="${CFLAGS:-} -Wno-unterminated-string-initialization" \
+	&& ./configure $NGINX_CONFIG \
+	&& make -j$(getconf _NPROCESSORS_ONLN) \
+	&& mv objs/nginx objs/nginx-debug \
+	&& ./configure $NGINX_CONFIG \
+	&& make -j$(getconf _NPROCESSORS_ONLN)
 
 RUN \
     cd /usr/src/nginx-$NGINX_VERSION \

--- a/packages/alpine-node-nginx/Dockerfile-slim
+++ b/packages/alpine-node-nginx/Dockerfile-slim
@@ -78,6 +78,7 @@ RUN \
 
 RUN \
 	cd /usr/src/nginx-$NGINX_VERSION \
+	&& export CFLAGS="${CFLAGS:-} -Wno-unterminated-string-initialization" \
 	&& ./configure $NGINX_CONFIG \
 	&& make -j$(getconf _NPROCESSORS_ONLN) \
 	&& mv objs/nginx objs/nginx-debug \


### PR DESCRIPTION
### Проблема:
после обновления версии alpine перестал собираться образ
https://github.com/core-ds/arui-scripts/pull/486/changes
пример билда с ошибкой
https://github.com/core-ds/arui-scripts/actions/runs/25721652405/job/75527859047

### Мотивация:
CFLAGS это переменная окружения, которая содержит флаги компилятора C
В nginx используются бинарные литералы, для примера:
`static const u_char nginx[5] = "\x84\xaa\x63\x55\xe7"`
GCC 15 в Alpine 3.23 воспринимает строковые литералы без` \0` как ошибку
Видимо тут только ждать, когда сделают фикс в ngnix
