### PR TITLE
add reexport patchMainWebpackConfigForModules

### DIFF
--- a/.changeset/short-bobcats-impress.md
+++ b/.changeset/short-bobcats-impress.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': minor
+---
+
+добавлен рееэкспорт patchMainWebpackConfigForModules для публичного api, для исправления ошибки ERR_PACKAGE_PATH_NOT_EXPORTED в проектах. если нужна функция patchMainWebpackConfigForModules, то используйте `import { patchMainWebpackConfigForModules } from 'arui-scripts'`

--- a/packages/arui-scripts/src/index.ts
+++ b/packages/arui-scripts/src/index.ts
@@ -4,3 +4,4 @@ export type { AppConfigs, PackageSettings } from './configs/app-configs/types';
 export { prepareFilesForDocker } from './commands/util/docker-build';
 export { getBuildParamsFromArgs } from './commands/util/docker-build';
 export { getDockerBuildCommand } from './commands/util/docker-build';
+export { patchMainWebpackConfigForModules } from './configs/modules';


### PR DESCRIPTION
добавлен рееэкспорт patchMainWebpackConfigForModules для публичного api, для исправления ошибки ERR_PACKAGE_PATH_NOT_EXPORTED в проектах. если нужна функция patchMainWebpackConfigForModules, то используйте `import { patchMainWebpackConfigForModules } from 'arui-scripts'`