### PR TITLE
remove unused import get-port in run-client-dev-server

### DIFF
--- a/.changeset/beige-planes-destroy.md
+++ b/.changeset/beige-planes-destroy.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+удален неиспользуемый импорт get-port в файле run-client-dev-server.ts

--- a/packages/arui-scripts/src/commands/util/run-client-dev-server.ts
+++ b/packages/arui-scripts/src/commands/util/run-client-dev-server.ts
@@ -2,7 +2,6 @@ import { types } from 'util';
 
 import { type Configuration, rspack, type Stats } from '@rspack/core';
 import { RspackDevServer } from '@rspack/dev-server';
-import getPort from 'get-port';
 
 import { devServerConfig } from '../../configs/dev-server';
 import { printCompilerOutput } from '../start/print-compiler-output';


### PR DESCRIPTION
тут что-то пошло не так https://github.com/core-ds/arui-scripts/pull/483
не проходит команда `yarn lint`

<img width="1122" height="561" alt="Снимок экрана 2026-05-12 в 18 44 59" src="https://github.com/user-attachments/assets/149b899c-5197-4fa1-862c-7eeb8dd5df28" />