### PR TITLE
feat(arui-scripts): export type CompatModuleConfig

### DIFF
--- a/.changeset/moody-lions-rule.md
+++ b/.changeset/moody-lions-rule.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': minor
+---
+
+добавлен экспорт типа CompatModuleConfig

--- a/packages/arui-scripts/src/index.ts
+++ b/packages/arui-scripts/src/index.ts
@@ -1,6 +1,6 @@
 export type { OverrideFile } from './configs/util/apply-overrides';
 
-export type { AppConfigs, PackageSettings } from './configs/app-configs/types';
+export type { AppConfigs, CompatModuleConfig, PackageSettings } from './configs/app-configs/types';
 export { prepareFilesForDocker } from './commands/util/docker-build';
 export { getBuildParamsFromArgs } from './commands/util/docker-build';
 export { getDockerBuildCommand } from './commands/util/docker-build';


### PR DESCRIPTION
для типизации настроек в проектах нужен тип CompatModuleConfig