### PR TITLE
fix run bundle-analyze

### DIFF
--- a/.changeset/angry-donuts-act.md
+++ b/.changeset/angry-donuts-act.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Исправлен запуск команды `bundle-analyze`. Теперь явно включаются необходимые поля stats для `webpack-bundle-analyzer`, которые больше не попадают в `stats.toJson()` по умолчанию

--- a/packages/arui-scripts/src/commands/bundle-analyze/index.ts
+++ b/packages/arui-scripts/src/commands/bundle-analyze/index.ts
@@ -1,10 +1,36 @@
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
-import { rspack, type WebpackPluginInstance } from '@rspack/core';
+import {
+    rspack,
+    type RspackOptionsNormalized,
+    type WebpackPluginInstance,
+} from '@rspack/core';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 import { configs } from '../../configs/app-configs';
 import { webpackClientConfig } from '../../configs/webpack.client.prod';
 import { makeTmpDir } from '../util/make-tmp-dir';
+
+type BundleAnalyzerStatsOptions = {
+    assets: boolean;
+    chunks: boolean;
+    chunkGroups: boolean;
+    chunkModules: boolean;
+    entryPoints: boolean;
+    entrypoints: boolean;
+    modules: boolean;
+};
+
+// В rspack по умолчанию больше не включаются эти поля, но для webpack-bundle-analyzer они нужны
+// https://rspack.rs/guide/migration/rspack_1.x#changed-default-parameters-of-statstojson
+const bundleAnalyzerStatsOptions: BundleAnalyzerStatsOptions = {
+    assets: true,
+    chunks: true,
+    chunkGroups: true,
+    chunkModules: true,
+    entryPoints: true,
+    entrypoints: true,
+    modules: true,
+};
 
 (async () => {
     console.log('Starting bundle analysis...');
@@ -16,12 +42,17 @@ import { makeTmpDir } from '../util/make-tmp-dir';
     /* eslint-disable no-param-reassign */
     const promises = clientWebpackConfigs.map(async (webpackConfig, i) => {
         const tmpDir = await makeTmpDir(i.toString());
+        const webpackStatsOptions: RspackOptionsNormalized['stats'] = {
+            ...(typeof webpackConfig.stats === 'object' ? webpackConfig.stats : {}),
+            ...bundleAnalyzerStatsOptions,
+        };
 
         webpackConfig.plugins = [
             ...(webpackConfig.plugins || []),
             new BundleAnalyzerPlugin({
                 generateStatsFile: true,
                 statsFilename: configs.statsOutputPath,
+                statsOptions: bundleAnalyzerStatsOptions,
                 analyzerPort: 'auto',
                 analyzerMode: 'server',
                 openAnalyzer: true,
@@ -29,6 +60,7 @@ import { makeTmpDir } from '../util/make-tmp-dir';
             }) as unknown as WebpackPluginInstance, // webpack-bundle-analyzer has incorrect types
             new RsdoctorRspackPlugin({}),
         ];
+        webpackConfig.stats = webpackStatsOptions;
         webpackConfig.output = {
             ...webpackConfig.output,
             path: tmpDir,


### PR DESCRIPTION
Исправлен запуск команды `bundle-analyze`. Теперь явно включаются необходимые поля stats для 
`webpack-bundle-analyzer`, которые больше не попадают в `stats.toJson()` по умолчанию

https://rspack.rs/guide/migration/rspack_1.x#changed-default-parameters-of-statstojson

