### PR TITLE
fix(arui-scripts): isolate wmf separate build runtime

### DIFF
--- a/.changeset/big-jeans-battle.md
+++ b/.changeset/big-jeans-battle.md
@@ -1,0 +1,5 @@
+---
+'arui-scripts': patch
+---
+
+Исправление конфликта runtime-чанков между основной сборкой и отдельной WMF-сборкой при использовании modules.options.useSeparateBuild

--- a/packages/arui-scripts/src/configs/__tests__/webpack-client-modules.tests.ts
+++ b/packages/arui-scripts/src/configs/__tests__/webpack-client-modules.tests.ts
@@ -1,0 +1,42 @@
+import { type Configuration } from '@rspack/core';
+
+import { configs } from '../app-configs';
+import { MODULES_SEPARATE_BUILD_NAME } from '../modules';
+import { createClientWebpackConfig } from '../webpack.client';
+
+describe('client webpack config for modules', () => {
+    const originalModules = configs.modules;
+    const originalNormalizedName = configs.normalizedName;
+
+    afterEach(() => {
+        configs.modules = originalModules;
+        configs.normalizedName = originalNormalizedName;
+    });
+
+    it('isolates separate wmf build runtime from main application runtime', () => {
+        configs.normalizedName = 'test_app';
+        configs.modules = {
+            exposes: {
+                testModule: './src/modules/test-module',
+            },
+            shared: {},
+            options: {
+                useSeparateBuild: true,
+            },
+        };
+
+        const clientConfig = createClientWebpackConfig('prod') as Configuration[];
+        const mainConfig = clientConfig.find((config) => !config.name);
+        const wmfConfig = clientConfig.find(
+            (config) => config.name === MODULES_SEPARATE_BUILD_NAME,
+        );
+
+        expect(wmfConfig?.output).toMatchObject({
+            uniqueName: 'test_app_wmf',
+            chunkLoadingGlobal: 'rspackChunktest_app_wmf',
+        });
+        expect(mainConfig?.output).not.toMatchObject({
+            chunkLoadingGlobal: 'rspackChunktest_app_wmf',
+        });
+    });
+});

--- a/packages/arui-scripts/src/configs/modules.ts
+++ b/packages/arui-scripts/src/configs/modules.ts
@@ -12,6 +12,18 @@ export function haveExposedDefaultModules() {
 }
 
 export const MODULES_ENTRY_NAME = 'remoteEntry.js';
+export const MODULES_SEPARATE_BUILD_NAME = 'wmf';
+
+function getModuleFederationContainerName() {
+    return configs.modules?.name || configs.normalizedName;
+}
+
+function getSeparateBuildRuntimeName() {
+    return `${getModuleFederationContainerName().replace(
+        /\W/g,
+        '_',
+    )}_${MODULES_SEPARATE_BUILD_NAME}`;
+}
 
 export function patchMainWebpackConfigForModules(
     webpackConf: rspack.Configuration,
@@ -55,9 +67,19 @@ export function patchMainWebpackConfigForModules(
         ? 'auto' // Для того чтобы модули могли подключаться из разных мест, нам необходимо использовать auto. Для корректной работы в IE надо подключaть https://github.com/amiller-gh/currentScript-polyfill
         : configs.publicPath;
 
+    if (mode === 'provider') {
+        const uniqueName = getSeparateBuildRuntimeName();
+
+        webpackConf.output = {
+            ...webpackConf.output,
+            uniqueName,
+            chunkLoadingGlobal: `rspackChunk${uniqueName}`,
+        };
+    }
+
     webpackConf.plugins.push(
         new rspack.container.ModuleFederationPlugin({
-            name: configs.modules.name || configs.normalizedName,
+            name: getModuleFederationContainerName(),
             filename: isProvider && configs.modules.exposes ? MODULES_ENTRY_NAME : undefined,
             shared:
                 (mode === 'provider' && configs.modules.options?.separateBuildShared) ||
@@ -65,7 +87,7 @@ export function patchMainWebpackConfigForModules(
             exposes: isProvider ? configs.modules.exposes : {},
             shareScope: configs.modules.shareScope,
         }),
-        new TurnOffSplitRemoteEntry(configs.modules.name || configs.normalizedName),
+        new TurnOffSplitRemoteEntry(getModuleFederationContainerName()),
     );
 
     return webpackConf;

--- a/packages/arui-scripts/src/configs/webpack.client.ts
+++ b/packages/arui-scripts/src/configs/webpack.client.ts
@@ -36,7 +36,11 @@ import { configs } from './app-configs';
 import { babelClientConfig as babelConf } from './babel-client';
 import { babelDependencies } from './babel-dependencies';
 import { addEnvToHtmlTemplate, ClientConfigPlugin } from './client-env-config';
-import { patchMainWebpackConfigForModules, patchWebpackConfigForCompat } from './modules';
+import {
+    MODULES_SEPARATE_BUILD_NAME,
+    patchMainWebpackConfigForModules,
+    patchWebpackConfigForCompat,
+} from './modules';
 import { postcssConfig as postcssConf } from './postcss';
 import { processAssetsPluginOutput } from './process-assets-plugin-output';
 import { swcClientConfig } from './swc';
@@ -410,7 +414,7 @@ export const createClientWebpackConfig = (mode: 'dev' | 'prod') => {
         baseWebpackConfig[0] = patchMainWebpackConfigForModules(baseWebpackConfig[0], 'consumer');
         baseWebpackConfig.push(
             patchMainWebpackConfigForModules(
-                createSingleClientWebpackConfig(mode, {}, 'wmf'),
+                createSingleClientWebpackConfig(mode, {}, MODULES_SEPARATE_BUILD_NAME),
                 'provider',
             ),
         );


### PR DESCRIPTION
основной app bundle и `remoteEntry.js` использовали один `rspackChunk...` namespace. Из-за этого могли конфликтовать module Id  между main/vendor и WMF chunks, что приводило к рантайм ошибкам вида:

<img width="1230" height="484" alt="image" src="https://github.com/user-attachments/assets/9e536966-70f1-4761-902f-425e14f53a4d" />
<img width="1280" height="697" alt="image" src="https://github.com/user-attachments/assets/c4347d10-4f8c-4130-8970-f7e82ee38931" />

Как было у меня:

Экспортирую свой модуль с useSeparateBuild: true.
Использую загрузчик этого модуля у себя  в приложении => падает на стендах на моем экране, на локалке все отрабатывает нормально.
На потребителях, кто юзает мой модуль - работает

Теперь provider-only `wmf` config получает отдельные:

- `output.uniqueName`
- `output.chunkLoadingGlobal`





