### PR TITLE
отключить csrf для hapi20 getModuleResources

### DIFF
--- a/.changeset/hapi20-get-module-resources-csrf.md
+++ b/.changeset/hapi20-get-module-resources-csrf.md
@@ -1,0 +1,5 @@
+---
+'@alfalab/scripts-server': patch
+---
+
+Отключает CSRF-проверку для Hapi20 getModuleResources, сохраняя дополнительные routeParams plugins.

--- a/packages/arui-scripts-server/src/__tests__/hapi-20.tests.ts
+++ b/packages/arui-scripts-server/src/__tests__/hapi-20.tests.ts
@@ -1,0 +1,53 @@
+import { createGetModulesHapi20Plugin } from '../hapi-20';
+
+describe('createGetModulesHapi20Plugin', () => {
+    function getRouteConfig(routeParams?: Record<string, unknown>) {
+        const plugin = createGetModulesHapi20Plugin({}, routeParams);
+        const server = {
+            route: jest.fn(),
+        };
+
+        plugin.register(server as never, {} as never);
+
+        return server.route.mock.calls[0][0];
+    }
+
+    it('should ignore csrf check by default', () => {
+        const routeConfig = getRouteConfig();
+
+        expect(routeConfig.options).toMatchObject({
+            plugins: {
+                crumb: {
+                    ignore: true,
+                },
+            },
+        });
+    });
+
+    it('should keep additional route plugins', () => {
+        const routeConfig = getRouteConfig({
+            auth: false,
+            plugins: {
+                crumb: {
+                    key: 'custom-crumb-key',
+                },
+                customPlugin: {
+                    enabled: true,
+                },
+            },
+        });
+
+        expect(routeConfig.options).toMatchObject({
+            auth: false,
+            plugins: {
+                crumb: {
+                    key: 'custom-crumb-key',
+                    ignore: true,
+                },
+                customPlugin: {
+                    enabled: true,
+                },
+            },
+        });
+    });
+});

--- a/packages/arui-scripts-server/src/hapi-20.ts
+++ b/packages/arui-scripts-server/src/hapi-20.ts
@@ -4,11 +4,17 @@ import { type GetResourcesRequest } from '@alfalab/scripts-modules';
 
 import { createGetModulesMethod, type ModulesConfig } from './modules';
 
+type RoutePlugins = Record<string, unknown> & {
+    crumb?: Record<string, unknown>;
+};
+
 export function createGetModulesHapi20Plugin(
     modules: ModulesConfig<[Request]>,
     routeParams?: Record<string, unknown>,
 ) {
     const modulesMethodSettings = createGetModulesMethod(modules);
+    const routePlugins = routeParams?.plugins as RoutePlugins;
+    const crumbPlugin = routePlugins?.crumb ?? {};
 
     const plugin: Plugin<Record<string, never>> = {
         name: `@alfalab/scripts-server${modulesMethodSettings.path}`,
@@ -19,6 +25,13 @@ export function createGetModulesHapi20Plugin(
                 path: modulesMethodSettings.path,
                 options: {
                     ...routeParams,
+                    plugins: {
+                        ...routePlugins,
+                        crumb: {
+                            ignore: true,
+                            ...crumbPlugin,
+                        },
+                    },
                 },
                 handler: async (request, h) => {
                     try {


### PR DESCRIPTION
В hapi16 get module resource выставлял флаг crumb ignore = true
в hapi20 get module resource видимо забыли

Из-за чего сейчас загрузка модулей падает с 403 ошибкой и приходится прокидывать вторым аргументом этот флаг в лоадер
```ts
plugins: {
      crumb: {
          ignore: true,
      },
  },
```

https://git.moscow.alfaintra.net/projects/CORP-GOODS-PURCHASES/repos/corp-buyers-ui/pull-requests/35/diff#src%2Fserver%2Fplugins%2Fget-module-resources.ts?t=32