### PR TITLE
feat(docker-build:compiled): автоматический symlink на yarn бинарник при yarn 2+ с yarnPath

### DIFF
--- a/.changeset/eighty-rocks-appear.md
+++ b/.changeset/eighty-rocks-appear.md
@@ -1,0 +1,5 @@
+---
+"arui-scripts": minor
+---
+
+Добавлен автоматический symlink на yarn бинарник в Dockerfile при использовании yarn 2+ с yarnPath в .yarnrc.yml. Это исправляет ошибку `yarn: not found` в Docker-образах (ни полный, ни slim-образ не содержат yarn).

--- a/packages/arui-scripts/src/commands/util/yarn.ts
+++ b/packages/arui-scripts/src/commands/util/yarn.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+
 import shell from 'shelljs';
 
 import { configs } from '../../configs/app-configs';
@@ -54,4 +57,51 @@ export function getInstallProductionCommand(): string {
             return '';
         }
     }
+}
+
+/**
+ * Читает значение yarnPath из .yarnrc.yml.
+ * Возвращает путь к бинарнику yarn (например .yarn/releases/yarn-4.18.0.cjs) или null.
+ */
+export function getYarnPathFromRc(): string | null {
+    const rcPath = path.join(configs.cwd, '.yarnrc.yml');
+
+    if (!shell.test('-f', rcPath)) {
+        return null;
+    }
+
+    let content: string;
+
+    try {
+        content = fs.readFileSync(rcPath, 'utf8');
+    } catch {
+        return null;
+    }
+
+    // Ищем строку вида: yarnPath: .yarn/releases/yarn-4.18.0.cjs
+    // Значение может быть в кавычках или без
+    const match = content.match(/^\s*yarnPath:\s*['"]?([^'"\s]+)['"]?\s*$/m);
+
+    return match ? match[1] : null;
+}
+
+/**
+ * Возвращает команду для создания symlink на yarn бинарник в Docker-образе.
+ * Используется при yarn 2+ с yarnPath в .yarnrc.yml, чтобы yarn был доступен
+ * в PATH внутри Docker-образов (где yarn не установлен глобально).
+ * Возвращает пустую строку, если symlink не нужен.
+ */
+export function getYarnBinSymlinkCommand(): string {
+    if (getYarnVersion() !== '2+') {
+        return '';
+    }
+
+    const yarnPath = getYarnPathFromRc();
+
+    if (!yarnPath) {
+        return '';
+    }
+
+    // WORKDIR в Dockerfile = /src
+    return `ln -s /src/${yarnPath} /usr/local/bin/yarn && \\\n    `;
 }

--- a/packages/arui-scripts/src/templates/__tests__/dockerfile-templates.tests.ts
+++ b/packages/arui-scripts/src/templates/__tests__/dockerfile-templates.tests.ts
@@ -35,6 +35,7 @@ describe('dockerfile.template (normal mode)', () => {
 describe('dockerfile-compiled.template (compiled mode)', () => {
     function getTemplate(deleteNpm: boolean) {
         jest.resetModules();
+
         jest.doMock('../../configs/app-configs', () => ({
             configs: {
                 baseDockerImage: 'test-image',
@@ -83,6 +84,7 @@ describe('dockerfile-compiled.template with yarn 2+ symlink', () => {
         yarnVersion?: '1' | '2+' | 'unavailable';
     }) {
         const { yarnPath = null, yarnVersion = '2+' } = opts;
+
         jest.resetModules();
         jest.doMock('../../configs/app-configs', () => ({
             configs: {

--- a/packages/arui-scripts/src/templates/__tests__/dockerfile-templates.tests.ts
+++ b/packages/arui-scripts/src/templates/__tests__/dockerfile-templates.tests.ts
@@ -46,6 +46,7 @@ describe('dockerfile-compiled.template (compiled mode)', () => {
         jest.doMock('../../commands/util/yarn', () => ({
             getInstallProductionCommand: () => 'npm install --production',
             getYarnVersion: () => 'unavailable',
+            getYarnBinSymlinkCommand: () => '',
         }));
 
         // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
@@ -73,5 +74,60 @@ describe('dockerfile-compiled.template (compiled mode)', () => {
 
         expect(rmStep).toBeGreaterThan(-1);
         expect(rmStep).toBeLessThan(userNginx);
+    });
+});
+
+describe('dockerfile-compiled.template with yarn 2+ symlink', () => {
+    function getTemplate(opts: {
+        yarnPath?: string | null;
+        yarnVersion?: '1' | '2+' | 'unavailable';
+    }) {
+        const { yarnPath = null, yarnVersion = '2+' } = opts;
+        jest.resetModules();
+        jest.doMock('../../configs/app-configs', () => ({
+            configs: {
+                baseDockerImage: 'test-image',
+                nginx: null,
+                overridesPath: [],
+                deleteNpm: false,
+            },
+        }));
+        jest.doMock('../../commands/util/yarn', () => ({
+            getInstallProductionCommand: () =>
+                yarnVersion === '2+'
+                    ? 'yarn workspaces focus --production --all'
+                    : 'npm install --production',
+            getYarnVersion: () => yarnVersion,
+            getYarnBinSymlinkCommand: () =>
+                yarnPath ? `ln -s /src/${yarnPath} /usr/local/bin/yarn && \\\n    ` : '',
+        }));
+
+        // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+        return require('../dockerfile-compiled.template').dockerfileTemplate;
+    }
+
+    it('should add symlink when yarn 2+ with yarnPath', () => {
+        const template = getTemplate({
+            yarnPath: '.yarn/releases/yarn-4.18.0.cjs',
+        });
+
+        expect(template).toContain('ln -s /src/.yarn/releases/yarn-4.18.0.cjs /usr/local/bin/yarn');
+        expect(template).toContain('yarn workspaces focus --production --all');
+        expect(template).toContain('yarn cache clean --all');
+    });
+
+    it('should not add symlink when yarn 2+ without yarnPath', () => {
+        const template = getTemplate({ yarnPath: null });
+
+        expect(template).not.toContain('ln -s');
+        expect(template).toContain('yarn workspaces focus --production --all');
+    });
+
+    it('should not add symlink when npm (unavailable)', () => {
+        const template = getTemplate({ yarnVersion: 'unavailable' });
+
+        expect(template).not.toContain('ln -s');
+        expect(template).toContain('npm install --production');
+        expect(template).toContain('npm cache clean --force');
     });
 });

--- a/packages/arui-scripts/src/templates/dockerfile-compiled.template.ts
+++ b/packages/arui-scripts/src/templates/dockerfile-compiled.template.ts
@@ -1,9 +1,14 @@
-import { getInstallProductionCommand, getYarnVersion } from '../commands/util/yarn';
+import {
+    getInstallProductionCommand,
+    getYarnBinSymlinkCommand,
+    getYarnVersion,
+} from '../commands/util/yarn';
 import { configs } from '../configs/app-configs';
 import { applyOverrides } from '../configs/util/apply-overrides';
 
 const installProductionCommand = getInstallProductionCommand();
 const yarnVersion = getYarnVersion();
+const yarnBinSymlinkCommand = getYarnBinSymlinkCommand();
 
 const { nginx } = configs;
 
@@ -34,7 +39,7 @@ ${filesRequiredToInstallDependencies
     .map((file) => `ADD --chown=nginx:nginx ${file} /src/${file}`)
     .join('\n')}
 
-RUN ${installProductionCommand}  && \\
+RUN ${yarnBinSymlinkCommand}${installProductionCommand}  && \\
     ${yarnVersion === 'unavailable' ? 'npm cache clean --force' : 'yarn cache clean --all'}
 
 ADD --chown=nginx:nginx . /src


### PR DESCRIPTION
## Описание

При использовании yarn 2+ с `yarnPath` в `.yarnrc.yml`, сгенерированный Dockerfile автоматически создаёт symlink на yarn бинарник. Исправляет ошибку `yarn: not found` в Docker-образах, где yarn не установлен глобально.

## Проблема

Docker-образы arui-scripts (как `Dockerfile`, так и `Dockerfile-slim`) не содержат yarn. При использовании yarn 2+ с локальным бинарником (`yarnPath` в `.yarnrc.yml`), сгенерированный Dockerfile вызывает `yarn workspaces focus --production --all`, но `yarn` недоступен в `PATH`.

## Решение

- `getYarnPathFromRc()` — читает `yarnPath` из `.yarnrc.yml` проекта (regex, без зависимости js-yaml)
- `getYarnBinSymlinkCommand()` — возвращает команду `ln -s /src/<yarnPath> /usr/local/bin/yarn && \\\n    ` или пустую строку
- В `dockerfile-compiled.template.ts` команда подставляется перед установкой зависимостей

## Изменённые файлы

- `packages/arui-scripts/src/commands/util/yarn.ts` — добавлены `getYarnPathFromRc()` и `getYarnBinSymlinkCommand()`
- `packages/arui-scripts/src/templates/dockerfile-compiled.template.ts` — подстановка symlink в RUN layer
- `packages/arui-scripts/src/templates/__tests__/dockerfile-templates.tests.ts` — 3 новых теста
- `.changeset/eighty-rocks-appear.md` — changeset (minor)

## Проверка

- `yarn test` — 45 тестов passed (15 suites)
- `yarn docker-build` в delivery-sandbox-ui с локальным `yarn link` — сборка прошла успешно

## Чек-лист

- [x] Тесты добавлены
- [x] Changeset создан
- [x] Коммит на русском